### PR TITLE
Update install documentation to reflect actual go imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Here are some ideas for apps you could build with `us`:
 
 ## What do I need to get started?
 
-Run `go get github.com/lukechampine/us/...` to install `us` and its
+Run `go get lukechampine.com/us/...` to install `us` and its
 dependencies. For subsequent builds, run `make`. No pre-built binaries
 are provided at this time.
 


### PR DESCRIPTION
Actual go imports reference `lukechampine.com/us/`, not `github.com/lukechampine/us/`. Thus, to build the project out of the box with the `make` command you need to use the files installed from `go get lukechampine.com/us/...`, not `go get github.com/lukechampine/us/...`.