### PR TITLE
Add the host's public key to the contract header

### DIFF
--- a/cmd/user/main.go
+++ b/cmd/user/main.go
@@ -238,6 +238,12 @@ Serve the files in metafolder over HTTP.
 
 Mount metafolder as a read-only FUSE filesystem, rooted at folder.
 `
+	convertUsage = `Usage:
+    user convert contract
+
+Converts a v1 contract to v2. If conversion fails, the v1 contract is not
+affected.
+`
 )
 
 var usage = flagg.SimpleUsage(flagg.Root, rootUsage) // point-free style!
@@ -319,6 +325,7 @@ func main() {
 	serveCmd := flagg.New("serve", serveUsage)
 	sAddr := serveCmd.String("addr", ":8080", "HTTP service address")
 	mountCmd := flagg.New("mount", mountUsage)
+	convertCmd := flagg.New("convert", convertUsage)
 
 	cmd := flagg.Parse(flagg.Tree{
 		Cmd: rootCmd,
@@ -341,6 +348,7 @@ func main() {
 			{Cmd: recoverCmd},
 			{Cmd: serveCmd},
 			{Cmd: mountCmd},
+			{Cmd: convertCmd},
 		},
 	})
 	args := cmd.Args()
@@ -529,5 +537,12 @@ Define min_shards in your config file or supply the -m flag.`)
 		if err != nil {
 			log.Fatal(err)
 		}
+
+	case convertCmd:
+		if len(args) != 1 {
+			convertCmd.Usage()
+			return
+		}
+		check("Conversion failed:", renter.ConvertContractV1V2(args[0]))
 	}
 }

--- a/renter/contracts.go
+++ b/renter/contracts.go
@@ -54,7 +54,7 @@ func (h *ContractHeader) Validate() error {
 		return errors.Errorf("wrong magic bytes (%q)", h.magic)
 	}
 	if h.version != ContractVersion {
-		return errors.Errorf("wrong version (%d)", h.version)
+		return errors.Errorf("incompatible version (v%d): convert to v%d", h.version, ContractVersion)
 	}
 	return nil
 }

--- a/renter/contracts.go
+++ b/renter/contracts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"gitlab.com/NebulousLabs/Sia/crypto"
 	"gitlab.com/NebulousLabs/Sia/types"
+	"golang.org/x/crypto/ed25519"
 
 	"lukechampine.com/us/hostdb"
 	"lukechampine.com/us/merkle"
@@ -22,7 +23,7 @@ const (
 
 	// ContractHeaderSize is the size in bytes of the contract file header.
 	// It is also the offset at which the contract revision data begins.
-	ContractHeaderSize = 11 + 1 + 32 + 32 + 64
+	ContractHeaderSize = 11 + 1 + 32 + 32 + 32
 
 	// ContractRootOffset is the offset at which the sector Merkle
 	// roots of the contract are stored.
@@ -197,7 +198,7 @@ func marshalHeader(contract proto.ContractRevision) []byte {
 	hpk := contract.HostKey().Ed25519()
 	buf.Write(hpk[:])
 	buf.Write(contract.Revision.ParentID[:])
-	buf.Write(contract.RenterKey[:])
+	buf.Write(contract.RenterKey[:32])
 	return buf.Bytes()
 }
 
@@ -209,7 +210,7 @@ func unmarshalHeader(b []byte) (h ContractHeader) {
 	copy(hpk[:], buf.Next(32))
 	h.hostKey = hostdb.HostPublicKey(types.Ed25519PublicKey(hpk).String())
 	copy(h.id[:], buf.Next(32))
-	copy(h.key[:], buf.Next(64))
+	copy(h.key[:], ed25519.NewKeyFromSeed(buf.Next(32)))
 	return h
 }
 

--- a/renter/convert.go
+++ b/renter/convert.go
@@ -1,0 +1,84 @@
+package renter
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+	"lukechampine.com/us/renter/proto"
+)
+
+// ConvertContractV1V2 converts a v1 contract to a v2 contract. The operation is
+// atomic: if conversion fails, the v1 contract file will be unchanged.
+func ConvertContractV1V2(filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return errors.Wrap(err, "could not open contract file")
+	}
+	defer f.Close()
+
+	// read header+revision+stack
+	b := make([]byte, ContractRootOffset)
+	if _, err := io.ReadFull(f, b); err != nil {
+		return errors.Wrap(err, "could not read contract metadata")
+	}
+	// decode and validate header
+	var h ContractHeader
+	buf := bytes.NewBuffer(b[:ContractHeaderSize])
+	if string(buf.Next(len(ContractMagic))) != ContractMagic {
+		return errors.New("wrong magic bytes")
+	}
+	if version, _ := buf.ReadByte(); version != 1 {
+		return errors.Errorf("expected version 1, got %v", version)
+	}
+	copy(h.id[:], buf.Next(32))
+	copy(h.key[:], buf.Next(64))
+
+	// decode revision
+	var rev proto.ContractRevision
+	buf = bytes.NewBuffer(b[ContractHeaderSize:])
+	if err := rev.Revision.UnmarshalSia(buf); err != nil {
+		return err
+	} else if err := rev.Signatures[0].UnmarshalSia(buf); err != nil {
+		return err
+	} else if err := rev.Signatures[1].UnmarshalSia(buf); err != nil {
+		return err
+	}
+
+	// write the converted contract to disk
+	out, err := ioutil.TempFile("", "")
+	if err != nil {
+		return errors.Wrap(err, "could not create temp file to hold new contract")
+	}
+	defer out.Close()
+
+	buf = bytes.NewBuffer(make([]byte, 0, ContractHeaderSize))
+	buf.WriteString(ContractMagic)
+	buf.WriteByte(2) // version
+	hpk := rev.HostKey().Ed25519()
+	buf.Write(hpk[:])
+	buf.Write(h.id[:])
+	buf.Write(h.key[:32])
+	if _, err := buf.WriteTo(out); err != nil {
+		return errors.Wrap(err, "could not write header")
+	}
+
+	// copy everything else directly
+	if _, err := f.Seek(ContractHeaderSize, io.SeekStart); err != nil {
+		return err
+	} else if _, err := out.Seek(ContractHeaderSize, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, f); err != nil {
+		return errors.Wrap(err, "could not copy contract data")
+	} else if err := out.Sync(); err != nil {
+		return errors.Wrap(err, "could not sync new contract file")
+	}
+	// atomically replace the old contract
+	if err := os.Rename(out.Name(), filename); err != nil {
+		return errors.Wrap(err, "could not overwrite old contract")
+	}
+	return nil
+}


### PR DESCRIPTION
Resolves #3.

The only departure from the proposal is that `user` isn't great about guiding you towards the `convert` command. The problem is that there are lots of places where `user` loads contracts, and I don't want to add code in every place that catches the specific version error and prints a nice message. So instead you'll get a generic error (`incompatible version (v1): convert to v2`) and hopefully infer that `user convert` is a valid command.

