### PR TITLE
Reconnect Sessions if they close prematurely

### DIFF
--- a/renter/proto/session.go
+++ b/renter/proto/session.go
@@ -65,6 +65,9 @@ func (s *Session) HostKey() hostdb.HostPublicKey { return s.host.PublicKey }
 // Revision returns the most recent revision of the locked contract.
 func (s *Session) Revision() ContractRevision { return s.rev }
 
+// IsClosed returns whether the Session is closed.
+func (s *Session) IsClosed() bool { return s.sess.IsClosed() }
+
 // SetLatency sets the latency deadline for RPCs.
 func (s *Session) SetLatency(d time.Duration) { s.latency = d }
 

--- a/renter/proto/session.go
+++ b/renter/proto/session.go
@@ -630,7 +630,7 @@ func NewUnlockedSession(hostIP modules.NetAddress, hostKey hostdb.HostPublicKey,
 // same as above, but without error wrapping, since we call it from NewSession too.
 func newUnlockedSession(hostIP modules.NetAddress, hostKey hostdb.HostPublicKey, currentHeight types.BlockHeight) (_ *Session, err error) {
 	start := time.Now()
-	conn, err := net.Dial("tcp", string(hostIP))
+	conn, err := net.DialTimeout("tcp", string(hostIP), 60*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/renter/renterutil/hostset.go
+++ b/renter/renterutil/hostset.go
@@ -130,7 +130,11 @@ func (set *HostSet) tryAcquire(host hostdb.HostPublicKey) (*proto.Session, error
 }
 
 func (set *HostSet) release(host hostdb.HostPublicKey) {
-	set.sessions[host].mu.Unlock()
+	lh := set.sessions[host]
+	if lh.s.IsClosed() {
+		lh.s = nil // force a reconnect
+	}
+	lh.mu.Unlock()
 }
 
 // AddHost adds a host to the set for later use.


### PR DESCRIPTION
Previously, we continued to use a `Session` even if an earlier RPC had returned an error. This meant that we were attempting to talk to a host that had closed its end of the connection, which caused confusing `broken pipe` errors.

The session code will now set a flag and close the connection when an I/O or authentication error occurs. The `HostSet` type will check this flag and automatically reconnect if necessary. I tested this by injecting random faults into `ghost` (timing out early 1/10th of the time), and all of the renterutil tests still passed, indicating that the code is now robust to transient errors.

Note that the errors are not suppressed; if a `Read` fails because too many hosts timed out, you'll still see the error. The difference is that now, if only one host failed due to a timeout, the *next* time you attempt a `Read` from that host, you'll use a new `Session` instead of the old one (which would have immediately returned `broken pipe`).