### PR TITLE
Add support for RPCRenewAndClear

### DIFF
--- a/renter/proto/renew.go
+++ b/renter/proto/renew.go
@@ -1,9 +1,11 @@
 package proto
 
 import (
+	"math"
 	"time"
 
 	"github.com/pkg/errors"
+	"gitlab.com/NebulousLabs/Sia/build"
 	"gitlab.com/NebulousLabs/Sia/crypto"
 	"gitlab.com/NebulousLabs/Sia/types"
 
@@ -23,6 +25,9 @@ func RenewContract(w Wallet, tpool TransactionPool, id types.FileContractID, key
 	defer s.Close()
 	if err := s.Lock(id, key); err != nil {
 		return ContractRevision{}, nil, err
+	}
+	if build.VersionCmp(s.host.Version, "1.4.4") >= 0 {
+		return s.RenewAndClearContract(w, tpool, renterPayout, startHeight, endHeight)
 	}
 	return s.RenewContract(w, tpool, renterPayout, startHeight, endHeight)
 }
@@ -201,6 +206,204 @@ func (s *Session) RenewContract(w Wallet, tpool TransactionPool, renterPayout ty
 
 	// Read the host signatures.
 	var hostSigs renterhost.RPCFormContractSignatures
+	if err := s.sess.ReadResponse(&hostSigs, 4096); err != nil {
+		return ContractRevision{}, nil, err
+	}
+	txn.TransactionSignatures = append(txn.TransactionSignatures, hostSigs.ContractSignatures...)
+	signedTxnSet := append(resp.Parents, append(parents, txn)...)
+
+	return ContractRevision{
+		Revision:   initRevision,
+		Signatures: [2]types.TransactionSignature{renterRevisionSig, hostSigs.RevisionSignature},
+	}, signedTxnSet, nil
+}
+
+// RenewAndClearContract negotiates a new file contract and initial revision for
+// data already stored with a host. The old contract is "cleared," reverting its
+// filesize to zero.
+func (s *Session) RenewAndClearContract(w Wallet, tpool TransactionPool, renterPayout types.Currency, startHeight, endHeight types.BlockHeight) (_ ContractRevision, _ []types.Transaction, err error) {
+	defer wrapErr(&err, "RenewAndClearContract")
+	if endHeight < startHeight {
+		return ContractRevision{}, nil, errors.New("end height must be greater than start height")
+	}
+	// get two renter addresses: one for the renter refund output, one for the
+	// change output
+	refundAddr, err := w.NewWalletAddress()
+	if err != nil {
+		return ContractRevision{}, nil, errors.Wrap(err, "could not get an address to use")
+	}
+	changeAddr, err := w.NewWalletAddress()
+	if err != nil {
+		return ContractRevision{}, nil, errors.Wrap(err, "could not get an address to use")
+	}
+
+	// estimate collateral
+	var hostCollateral types.Currency
+	blockBytes := s.host.UploadBandwidthPrice.Add(s.host.StoragePrice).Add(s.host.DownloadBandwidthPrice).Mul64(uint64(endHeight - startHeight))
+	if !blockBytes.IsZero() {
+		bytes := renterPayout.Div(blockBytes)
+		hostCollateral = s.host.Collateral.Mul(bytes).Mul64(uint64(endHeight - startHeight))
+	}
+	// hostCollateral can't be greater than MaxCollateral, and (due to a host-
+	// side bug) it can't be zero either.
+	if hostCollateral.Cmp(s.host.MaxCollateral) > 0 {
+		hostCollateral = s.host.MaxCollateral
+	} else if hostCollateral.IsZero() {
+		hostCollateral = types.NewCurrency64(1)
+	}
+
+	// Calculate additional basePrice and baseCollateral. If the contract
+	// height did not increase, basePrice and baseCollateral are zero.
+	currentRevision := s.rev.Revision
+	var basePrice, baseCollateral types.Currency
+	if endHeight+s.host.WindowSize > currentRevision.NewWindowEnd {
+		timeExtension := uint64((endHeight + s.host.WindowSize) - currentRevision.NewWindowEnd)
+		basePrice = s.host.StoragePrice.Mul64(currentRevision.NewFileSize).Mul64(timeExtension)    // cost of data already covered by contract
+		baseCollateral = s.host.Collateral.Mul64(currentRevision.NewFileSize).Mul64(timeExtension) // same but collateral
+	}
+
+	// calculate payouts
+	hostPayout := s.host.ContractPrice.Add(hostCollateral).Add(basePrice)
+	payout := taxAdjustedPayout(renterPayout.Add(hostPayout))
+
+	// create file contract
+	fc := types.FileContract{
+		FileSize:       currentRevision.NewFileSize,
+		FileMerkleRoot: currentRevision.NewFileMerkleRoot,
+		WindowStart:    endHeight,
+		WindowEnd:      endHeight + s.host.WindowSize,
+		Payout:         payout,
+		UnlockHash:     currentRevision.NewUnlockHash,
+		RevisionNumber: 0,
+		ValidProofOutputs: []types.SiacoinOutput{
+			// renter
+			{Value: renterPayout, UnlockHash: refundAddr},
+			// host
+			{Value: hostPayout, UnlockHash: s.host.UnlockHash},
+		},
+		MissedProofOutputs: []types.SiacoinOutput{
+			// renter
+			{Value: renterPayout, UnlockHash: refundAddr},
+			// baseCollateral is not returned to host
+			{Value: hostPayout.Sub(basePrice.Add(baseCollateral)), UnlockHash: s.host.UnlockHash},
+			// void gets the spent storage fees, plus the collateral being risked
+			{Value: basePrice.Add(baseCollateral), UnlockHash: types.UnlockHash{}},
+		},
+	}
+
+	// Calculate how much the renter needs to pay. On top of the renterPayout,
+	// the renter is responsible for paying host.ContractPrice, the siafund
+	// tax, and a transaction fee.
+	_, maxFee, err := tpool.FeeEstimate()
+	if err != nil {
+		return ContractRevision{}, nil, errors.Wrap(err, "could not estimate transaction fee")
+	}
+	fee := maxFee.Mul64(estTxnSize)
+	totalCost := renterPayout.Add(s.host.ContractPrice).Add(types.Tax(startHeight, fc.Payout)).Add(fee)
+
+	// create and fund a transaction containing fc
+	txn := types.Transaction{
+		FileContracts: []types.FileContract{fc},
+		MinerFees:     []types.Currency{fee},
+	}
+	toSign, err := fundSiacoins(&txn, totalCost, changeAddr, w)
+	if err != nil {
+		return ContractRevision{}, nil, err
+	}
+
+	// include any unconfirmed parent transactions
+	parents, err := w.UnconfirmedParents(txn)
+	if err != nil {
+		return ContractRevision{}, nil, err
+	}
+
+	// construct the final revision of the old contract
+	finalOldRevision := currentRevision
+	newValid, _ := updateRevisionOutputs(&finalOldRevision, s.host.BaseRPCPrice, types.ZeroCurrency)
+	finalOldRevision.NewMissedProofOutputs = finalOldRevision.NewValidProofOutputs
+	finalOldRevision.NewFileSize = 0
+	finalOldRevision.NewFileMerkleRoot = crypto.Hash{}
+	finalOldRevision.NewRevisionNumber = math.MaxUint64
+
+	s.extendDeadline(120 * time.Second)
+	req := &renterhost.RPCRenewAndClearContractRequest{
+		Transactions:           append(parents, txn),
+		RenterKey:              s.rev.Revision.UnlockConditions.PublicKeys[0],
+		FinalValidProofValues:  newValid,
+		FinalMissedProofValues: newValid,
+	}
+	if err := s.sess.WriteRequest(renterhost.RPCRenewClearContractID, req); err != nil {
+		return ContractRevision{}, nil, err
+	}
+
+	var resp renterhost.RPCFormContractAdditions
+	if err := s.sess.ReadResponse(&resp, 65536); err != nil {
+		return ContractRevision{}, nil, err
+	}
+
+	// merge host additions with txn
+	txn.SiacoinInputs = append(txn.SiacoinInputs, resp.Inputs...)
+	txn.SiacoinOutputs = append(txn.SiacoinOutputs, resp.Outputs...)
+
+	// sign the txn
+	for _, id := range toSign {
+		txn.TransactionSignatures = append(txn.TransactionSignatures, types.TransactionSignature{
+			ParentID:       id,
+			PublicKeyIndex: 0,
+			CoveredFields:  types.CoveredFields{WholeTransaction: true},
+		})
+	}
+	err = w.SignTransaction(&txn, toSign)
+	if err != nil {
+		err = errors.Wrap(err, "failed to sign transaction")
+		s.sess.WriteResponse(nil, err)
+		return ContractRevision{}, nil, err
+	}
+
+	// calculate signatures added
+	var addedSignatures []types.TransactionSignature
+	for _, sig := range txn.TransactionSignatures {
+		for _, id := range toSign {
+			if id == sig.ParentID {
+				addedSignatures = append(addedSignatures, sig)
+				break
+			}
+		}
+	}
+
+	// create initial (no-op) revision, transaction, and signature
+	initRevision := types.FileContractRevision{
+		ParentID:          txn.FileContractID(0),
+		UnlockConditions:  currentRevision.UnlockConditions,
+		NewRevisionNumber: 1,
+
+		NewFileSize:           fc.FileSize,
+		NewFileMerkleRoot:     fc.FileMerkleRoot,
+		NewWindowStart:        fc.WindowStart,
+		NewWindowEnd:          fc.WindowEnd,
+		NewValidProofOutputs:  fc.ValidProofOutputs,
+		NewMissedProofOutputs: fc.MissedProofOutputs,
+		NewUnlockHash:         fc.UnlockHash,
+	}
+	renterRevisionSig := types.TransactionSignature{
+		ParentID:       crypto.Hash(initRevision.ParentID),
+		CoveredFields:  types.CoveredFields{FileContractRevisions: []uint64{0}},
+		PublicKeyIndex: 0,
+		Signature:      s.key.SignHash(renterhost.HashRevision(initRevision)),
+	}
+
+	// Send signatures.
+	renterSigs := &renterhost.RPCRenewAndClearContractSignatures{
+		ContractSignatures:     addedSignatures,
+		RevisionSignature:      renterRevisionSig,
+		FinalRevisionSignature: s.key.SignHash(renterhost.HashRevision(finalOldRevision)),
+	}
+	if err := s.sess.WriteResponse(renterSigs, nil); err != nil {
+		return ContractRevision{}, nil, err
+	}
+
+	// Read the host signatures.
+	var hostSigs renterhost.RPCRenewAndClearContractSignatures
 	if err := s.sess.ReadResponse(&hostSigs, 4096); err != nil {
 		return ContractRevision{}, nil, err
 	}

--- a/renterhost/encoding.go
+++ b/renterhost/encoding.go
@@ -313,6 +313,83 @@ func (r *RPCFormContractSignatures) unmarshalBuffer(b *objBuffer) error {
 	return b.Err()
 }
 
+// RPCRenewAndClear
+
+func (r *RPCRenewAndClearContractRequest) marshalledSize() int {
+	txnsSize := 24
+	for i := range r.Transactions {
+		txnsSize += (*objTransaction)(&r.Transactions[i]).marshalledSize()
+	}
+	txnsSize += (*objSiaPublicKey)(&r.RenterKey).marshalledSize()
+	for i := range r.FinalValidProofValues {
+		txnsSize += (*objCurrency)(&r.FinalValidProofValues[i]).marshalledSize()
+	}
+	for i := range r.FinalMissedProofValues {
+		txnsSize += (*objCurrency)(&r.FinalMissedProofValues[i]).marshalledSize()
+	}
+	return txnsSize
+}
+
+func (r *RPCRenewAndClearContractRequest) marshalBuffer(b *objBuffer) {
+	b.writePrefix(len(r.Transactions))
+	for i := range r.Transactions {
+		(*objTransaction)(&r.Transactions[i]).marshalBuffer(b)
+	}
+	(*objSiaPublicKey)(&r.RenterKey).marshalBuffer(b)
+	b.writePrefix(len(r.FinalValidProofValues))
+	for i := range r.FinalValidProofValues {
+		(*objCurrency)(&r.FinalValidProofValues[i]).marshalBuffer(b)
+	}
+	b.writePrefix(len(r.FinalMissedProofValues))
+	for i := range r.FinalMissedProofValues {
+		(*objCurrency)(&r.FinalMissedProofValues[i]).marshalBuffer(b)
+	}
+}
+
+func (r *RPCRenewAndClearContractRequest) unmarshalBuffer(b *objBuffer) error {
+	r.Transactions = make([]types.Transaction, b.readPrefix(sizeofTransaction))
+	for i := range r.Transactions {
+		(*objTransaction)(&r.Transactions[i]).unmarshalBuffer(b)
+	}
+	(*objSiaPublicKey)(&r.RenterKey).unmarshalBuffer(b)
+	r.FinalValidProofValues = make([]types.Currency, b.readPrefix(sizeofCurrency))
+	for i := range r.FinalValidProofValues {
+		(*objCurrency)(&r.FinalValidProofValues[i]).unmarshalBuffer(b)
+	}
+	r.FinalMissedProofValues = make([]types.Currency, b.readPrefix(sizeofCurrency))
+	for i := range r.FinalMissedProofValues {
+		(*objCurrency)(&r.FinalMissedProofValues[i]).unmarshalBuffer(b)
+	}
+	return b.Err()
+}
+
+func (r *RPCRenewAndClearContractSignatures) marshalledSize() int {
+	sigsSize := 16
+	for i := range r.ContractSignatures {
+		sigsSize += (*objTransactionSignature)(&r.ContractSignatures[i]).marshalledSize()
+	}
+	return sigsSize + (*objTransactionSignature)(&r.RevisionSignature).marshalledSize() + len(r.FinalRevisionSignature)
+}
+
+func (r *RPCRenewAndClearContractSignatures) marshalBuffer(b *objBuffer) {
+	b.writePrefix(len(r.ContractSignatures))
+	for i := range r.ContractSignatures {
+		(*objTransactionSignature)(&r.ContractSignatures[i]).marshalBuffer(b)
+	}
+	(*objTransactionSignature)(&r.RevisionSignature).marshalBuffer(b)
+	b.writePrefixedBytes(r.FinalRevisionSignature)
+}
+
+func (r *RPCRenewAndClearContractSignatures) unmarshalBuffer(b *objBuffer) error {
+	r.ContractSignatures = make([]types.TransactionSignature, b.readPrefix(sizeofTransactionSignature))
+	for i := range r.ContractSignatures {
+		(*objTransactionSignature)(&r.ContractSignatures[i]).unmarshalBuffer(b)
+	}
+	(*objTransactionSignature)(&r.RevisionSignature).unmarshalBuffer(b)
+	r.FinalRevisionSignature = b.readPrefixedBytes()
+	return b.Err()
+}
+
 // RPCLock
 
 func (r *RPCLockRequest) marshalledSize() int {

--- a/renterhost/session.go
+++ b/renterhost/session.go
@@ -501,14 +501,15 @@ var (
 
 // RPC IDs
 var (
-	RPCFormContractID  = newSpecifier("LoopFormContract")
-	RPCLockID          = newSpecifier("LoopLock")
-	RPCReadID          = newSpecifier("LoopRead")
-	RPCRenewContractID = newSpecifier("LoopRenew")
-	RPCSectorRootsID   = newSpecifier("LoopSectorRoots")
-	RPCSettingsID      = newSpecifier("LoopSettings")
-	RPCUnlockID        = newSpecifier("LoopUnlock")
-	RPCWriteID         = newSpecifier("LoopWrite")
+	RPCFormContractID       = newSpecifier("LoopFormContract")
+	RPCLockID               = newSpecifier("LoopLock")
+	RPCReadID               = newSpecifier("LoopRead")
+	RPCRenewContractID      = newSpecifier("LoopRenew")
+	RPCRenewClearContractID = newSpecifier("LoopRenewClear")
+	RPCSectorRootsID        = newSpecifier("LoopSectorRoots")
+	RPCSettingsID           = newSpecifier("LoopSettings")
+	RPCUnlockID             = newSpecifier("LoopUnlock")
+	RPCWriteID              = newSpecifier("LoopWrite")
 )
 
 // Read/Write actions
@@ -524,10 +525,19 @@ var (
 // RPC request/response objects
 type (
 	// RPCFormContractRequest contains the request parameters for the
-	// FormContract RPC.
+	// FormContract and RenewContract RPCs.
 	RPCFormContractRequest struct {
 		Transactions []types.Transaction
 		RenterKey    types.SiaPublicKey
+	}
+
+	// RPCRenewAndClearContractRequest contains the request parameters for the
+	// RenewAndClearContract RPC.
+	RPCRenewAndClearContractRequest struct {
+		Transactions           []types.Transaction
+		RenterKey              types.SiaPublicKey
+		FinalValidProofValues  []types.Currency
+		FinalMissedProofValues []types.Currency
 	}
 
 	// RPCFormContractAdditions contains the parent transaction, inputs, and
@@ -544,6 +554,16 @@ type (
 	RPCFormContractSignatures struct {
 		ContractSignatures []types.TransactionSignature
 		RevisionSignature  types.TransactionSignature
+	}
+
+	// RPCRenewAndClearContractSignatures contains the signatures for a contract
+	// transaction, initial revision, and final revision of the contract being
+	// renewed. These signatures are sent by both the renter and host during the
+	// RenewAndClear RPC.
+	RPCRenewAndClearContractSignatures struct {
+		ContractSignatures     []types.TransactionSignature
+		RevisionSignature      types.TransactionSignature
+		FinalRevisionSignature []byte
 	}
 
 	// RPCLockRequest contains the request parameters for the Lock RPC.


### PR DESCRIPTION
The `RenewAndClear` RPC is much the same as a standard `Renew`, except that it simultaneously "clears" the old contract. This causes renewals to behave less surprisingly: after a contract has been renewed, the old contract is no longer usable. Importantly, this allows the host to throw away the old contract instead of retaining it and submitting a storage proof.