### PR TITLE
RPCError implements Is function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	gitlab.com/NebulousLabs/Sia v1.4.1
 	go.etcd.io/bbolt v1.3.4
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/renterhost/session.go
+++ b/renterhost/session.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"strings"
 
 	"github.com/aead/chacha20/chacha"
 	"github.com/pkg/errors"
@@ -42,6 +43,11 @@ type RPCError struct {
 // Error implements the error interface.
 func (e *RPCError) Error() string {
 	return e.Description
+}
+
+// Is reports whether this error matches target.
+func (e *RPCError) Is(target error) bool {
+	return strings.Contains(e.Description, target.Error())
 }
 
 // helper type for encoding and decoding RPC response messages, which can

--- a/renterhost/session_test.go
+++ b/renterhost/session_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -16,6 +15,8 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 	"lukechampine.com/frand"
 )
+
+var ErrInvalidName = errors.New("invalid name")
 
 var randomTxn = func() types.Transaction {
 	txn := types.Transaction{
@@ -160,7 +161,7 @@ func TestSession(t *testing.T) {
 						return err
 					}
 					if name == "" {
-						err = hs.WriteResponse(nil, errors.New("invalid name"))
+						err = hs.WriteResponse(nil, ErrInvalidName)
 					} else {
 						err = hs.WriteResponse(arb{"Hello, " + name}, nil)
 					}
@@ -188,7 +189,7 @@ func TestSession(t *testing.T) {
 	}
 	if err := rs.WriteRequest(newSpecifier("Greet"), arb{""}); err != nil {
 		t.Fatal(err)
-	} else if err := rs.ReadResponse(arb{&resp}, 0); !strings.Contains(err.Error(), "invalid name") {
+	} else if err := rs.ReadResponse(arb{&resp}, 0); !errors.Is(err, ErrInvalidName) {
 		t.Fatal(err)
 	}
 	if err := rs.Close(); err != nil {
@@ -317,7 +318,7 @@ func TestRawMessage(t *testing.T) {
 						return err
 					}
 				default:
-					if err := hs.WriteResponse(nil, errors.New("invalid name")); err != nil {
+					if err := hs.WriteResponse(nil, ErrInvalidName); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
With this commit and #46, MR https://gitlab.com/NebulousLabs/Sia/-/merge_requests/4348,
we can compare a host error with pre-defined errors for example

```go
errors.Is(err, host.ErrBadFileSize)
```

This code would work even if the error is wrapped by `erros.Wrap` or other 3rd party error libraries
such as go-multierror.