### PR TITLE
Fix underflow and add collateral leeway

### DIFF
--- a/renter/proto/renew.go
+++ b/renter/proto/renew.go
@@ -327,8 +327,12 @@ func (s *Session) RenewAndClearContract(w Wallet, tpool TransactionPool, renterP
 	}
 
 	// construct the final revision of the old contract
+	finalPayment := s.host.BaseRPCPrice
+	if finalPayment.Cmp(currentRevision.ValidRenterPayout()) > 0 {
+		finalPayment = currentRevision.ValidRenterPayout()
+	}
 	finalOldRevision := currentRevision
-	newValid, _ := updateRevisionOutputs(&finalOldRevision, s.host.BaseRPCPrice, types.ZeroCurrency)
+	newValid, _ := updateRevisionOutputs(&finalOldRevision, finalPayment, types.ZeroCurrency)
 	finalOldRevision.NewMissedProofOutputs = finalOldRevision.NewValidProofOutputs
 	finalOldRevision.NewFileSize = 0
 	finalOldRevision.NewFileMerkleRoot = crypto.Hash{}

--- a/renter/proto/session.go
+++ b/renter/proto/session.go
@@ -525,6 +525,8 @@ func (s *Session) Write(actions []renterhost.RPCWriteAction) (err error) {
 	if rev.NewValidProofOutputs[0].Value.Cmp(price) < 0 {
 		return ErrInsufficientFunds
 	}
+	// hosts can also be picky about collateral, so subtract 5%.
+	collateral = collateral.MulFloat(0.95)
 
 	// cap the collateral to whatever is left; no sense complaining if there is
 	// insufficient collateral, as we agreed to the amount when we formed the


### PR DESCRIPTION
This fix will prevent the panic, but `siad` hosts will likely still reject the RPC with an error until the [upstream fix](https://gitlab.com/NebulousLabs/Sia/-/merge_requests/4630) is merged.