### PR TITLE
HostErrorSet implements Is interface

### DIFF
--- a/renter/renterutil/hostset.go
+++ b/renter/renterutil/hostset.go
@@ -45,6 +45,15 @@ func (hes HostErrorSet) Error() string {
 	return "\n" + strings.Join(strs, "\n")
 }
 
+func (hse HostErrorSet) Is(target error) bool {
+	for _, e := range hse {
+		if errors.Is(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
 type tryLock struct {
 	c    chan struct{}
 	once sync.Once


### PR DESCRIPTION
It'd be useful if `HostErrorSet` implements `Is` interface.

For example, if a function returns a wrapped HostErrorSet, you can check if the wrapped error set contains a specific error:
```go
err := errors.Wrap(renterutil.HostErrorSet([]*renterutil.HostError{....}, "message"))
if errors.Is(err, host.ErrLowHostMissedOutput){
  // at least, one host returns ErrLowHostMissedOutput.
  ...
}
```
