### PR TITLE
Add leeway to contract price

### DIFF
--- a/renter/proto/formcontract.go
+++ b/renter/proto/formcontract.go
@@ -81,8 +81,13 @@ func (s *Session) FormContract(w Wallet, tpool TransactionPool, key ed25519.Priv
 		hostCollateral = types.NewCurrency64(1)
 	}
 
+	// The host adjusts its contract price dynamically based on the current
+	// recommended transaction fee. We don't know how much it will have changed
+	// since we last scanned, but adding 5% leeway seems reasonable.
+	contractPrice := s.host.ContractPrice.MulFloat(1.05)
+
 	// calculate payouts
-	hostPayout := s.host.ContractPrice.Add(hostCollateral)
+	hostPayout := contractPrice.Add(hostCollateral)
 	payout := taxAdjustedPayout(renterPayout.Add(hostPayout))
 
 	// create file contract
@@ -111,14 +116,14 @@ func (s *Session) FormContract(w Wallet, tpool TransactionPool, key ed25519.Priv
 	}
 
 	// Calculate how much the renter needs to pay. On top of the renterPayout,
-	// the renter is responsible for paying host.ContractPrice, the siafund
-	// tax, and a transaction fee.
+	// the renter is responsible for paying the contractPrice, the siafund tax,
+	// and a transaction fee.
 	_, maxFee, err := tpool.FeeEstimate()
 	if err != nil {
 		return ContractRevision{}, nil, errors.Wrap(err, "could not estimate transaction fee")
 	}
 	fee := maxFee.Mul64(estTxnSize)
-	totalCost := renterPayout.Add(s.host.ContractPrice).Add(types.Tax(startHeight, fc.Payout)).Add(fee)
+	totalCost := renterPayout.Add(contractPrice).Add(types.Tax(startHeight, fc.Payout)).Add(fee)
 
 	// create and fund a transaction containing fc
 	txn := types.Transaction{

--- a/renter/proto/renew.go
+++ b/renter/proto/renew.go
@@ -77,8 +77,13 @@ func (s *Session) RenewContract(w Wallet, tpool TransactionPool, renterPayout ty
 		}
 	}
 
+	// The host adjusts its contract price dynamically based on the current
+	// recommended transaction fee. We don't know how much it will have changed
+	// since we last scanned, but adding 5% leeway seems reasonable.
+	contractPrice := s.host.ContractPrice.MulFloat(1.05)
+
 	// calculate payouts
-	hostPayout := s.host.ContractPrice.Add(hostCollateral).Add(basePrice)
+	hostPayout := contractPrice.Add(hostCollateral).Add(basePrice)
 	payout := taxAdjustedPayout(renterPayout.Add(hostPayout))
 
 	// create file contract
@@ -107,14 +112,14 @@ func (s *Session) RenewContract(w Wallet, tpool TransactionPool, renterPayout ty
 	}
 
 	// Calculate how much the renter needs to pay. On top of the renterPayout,
-	// the renter is responsible for paying host.ContractPrice, the siafund
-	// tax, and a transaction fee.
+	// the renter is responsible for paying the contractPrice, the siafund tax,
+	// and a transaction fee.
 	_, maxFee, err := tpool.FeeEstimate()
 	if err != nil {
 		return ContractRevision{}, nil, errors.Wrap(err, "could not estimate transaction fee")
 	}
 	fee := maxFee.Mul64(estTxnSize)
-	totalCost := renterPayout.Add(s.host.ContractPrice).Add(types.Tax(startHeight, fc.Payout)).Add(fee)
+	totalCost := renterPayout.Add(contractPrice).Add(types.Tax(startHeight, fc.Payout)).Add(fee)
 
 	// create and fund a transaction containing fc
 	txn := types.Transaction{

--- a/renter/proto/renew.go
+++ b/renter/proto/renew.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"gitlab.com/NebulousLabs/Sia/build"
 	"gitlab.com/NebulousLabs/Sia/crypto"
 	"gitlab.com/NebulousLabs/Sia/types"
 
@@ -27,207 +26,14 @@ func RenewContract(w Wallet, tpool TransactionPool, id types.FileContractID, key
 	if err := s.Lock(id, key, 10*time.Second); err != nil {
 		return ContractRevision{}, nil, err
 	}
-	if build.VersionCmp(s.host.Version, "1.4.4") >= 0 {
-		return s.RenewAndClearContract(w, tpool, renterPayout, startHeight, endHeight)
-	}
 	return s.RenewContract(w, tpool, renterPayout, startHeight, endHeight)
 }
 
 // RenewContract negotiates a new file contract and initial revision for data
-// already stored with a host.
+// already stored with a host. The old contract is "cleared," reverting its
+// filesize to zero.
 func (s *Session) RenewContract(w Wallet, tpool TransactionPool, renterPayout types.Currency, startHeight, endHeight types.BlockHeight) (_ ContractRevision, _ []types.Transaction, err error) {
 	defer wrapErr(&err, "RenewContract")
-	if endHeight < startHeight {
-		return ContractRevision{}, nil, errors.New("end height must be greater than start height")
-	}
-	// get two renter addresses: one for the renter refund output, one for the
-	// change output
-	refundAddr, err := w.NewWalletAddress()
-	if err != nil {
-		return ContractRevision{}, nil, errors.Wrap(err, "could not get an address to use")
-	}
-	changeAddr, err := w.NewWalletAddress()
-	if err != nil {
-		return ContractRevision{}, nil, errors.Wrap(err, "could not get an address to use")
-	}
-
-	// estimate collateral
-	var hostCollateral types.Currency
-	blockBytes := s.host.UploadBandwidthPrice.Add(s.host.StoragePrice).Add(s.host.DownloadBandwidthPrice).Mul64(uint64(endHeight - startHeight))
-	if !blockBytes.IsZero() {
-		bytes := renterPayout.Div(blockBytes)
-		hostCollateral = s.host.Collateral.Mul(bytes).Mul64(uint64(endHeight - startHeight))
-	}
-	// hostCollateral can't be greater than MaxCollateral, and (due to a host-
-	// side bug) it can't be zero either.
-	if hostCollateral.Cmp(s.host.MaxCollateral) > 0 {
-		hostCollateral = s.host.MaxCollateral
-	} else if hostCollateral.IsZero() {
-		hostCollateral = types.NewCurrency64(1)
-	}
-
-	// Calculate additional basePrice and baseCollateral. If the contract
-	// height did not increase, basePrice and baseCollateral are zero.
-	currentRevision := s.rev.Revision
-	var basePrice, baseCollateral types.Currency
-	if endHeight+s.host.WindowSize > currentRevision.NewWindowEnd {
-		timeExtension := uint64((endHeight + s.host.WindowSize) - currentRevision.NewWindowEnd)
-		basePrice = s.host.StoragePrice.Mul64(currentRevision.NewFileSize).Mul64(timeExtension)    // cost of data already covered by contract
-		baseCollateral = s.host.Collateral.Mul64(currentRevision.NewFileSize).Mul64(timeExtension) // same but collateral
-		// prevent underflow
-		if baseCollateral.Cmp(hostCollateral) > 0 {
-			baseCollateral = hostCollateral
-		}
-	}
-
-	// calculate payouts
-	hostPayout := s.host.ContractPrice.Add(hostCollateral).Add(basePrice)
-	payout := taxAdjustedPayout(renterPayout.Add(hostPayout))
-
-	// create file contract
-	fc := types.FileContract{
-		FileSize:       currentRevision.NewFileSize,
-		FileMerkleRoot: currentRevision.NewFileMerkleRoot,
-		WindowStart:    endHeight,
-		WindowEnd:      endHeight + s.host.WindowSize,
-		Payout:         payout,
-		UnlockHash:     currentRevision.NewUnlockHash,
-		RevisionNumber: 0,
-		ValidProofOutputs: []types.SiacoinOutput{
-			// renter
-			{Value: renterPayout, UnlockHash: refundAddr},
-			// host
-			{Value: hostPayout, UnlockHash: s.host.UnlockHash},
-		},
-		MissedProofOutputs: []types.SiacoinOutput{
-			// renter
-			{Value: renterPayout, UnlockHash: refundAddr},
-			// baseCollateral is not returned to host
-			{Value: hostPayout.Sub(basePrice.Add(baseCollateral)), UnlockHash: s.host.UnlockHash},
-			// void gets the spent storage fees, plus the collateral being risked
-			{Value: basePrice.Add(baseCollateral), UnlockHash: types.UnlockHash{}},
-		},
-	}
-
-	// Calculate how much the renter needs to pay. On top of the renterPayout,
-	// the renter is responsible for paying host.ContractPrice, the siafund
-	// tax, and a transaction fee.
-	_, maxFee, err := tpool.FeeEstimate()
-	if err != nil {
-		return ContractRevision{}, nil, errors.Wrap(err, "could not estimate transaction fee")
-	}
-	fee := maxFee.Mul64(estTxnSize)
-	totalCost := renterPayout.Add(s.host.ContractPrice).Add(types.Tax(startHeight, fc.Payout)).Add(fee)
-
-	// create and fund a transaction containing fc
-	txn := types.Transaction{
-		FileContracts: []types.FileContract{fc},
-		MinerFees:     []types.Currency{fee},
-	}
-	toSign, err := fundSiacoins(&txn, totalCost, changeAddr, w)
-	if err != nil {
-		return ContractRevision{}, nil, err
-	}
-
-	// include any unconfirmed parent transactions
-	parents, err := w.UnconfirmedParents(txn)
-	if err != nil {
-		return ContractRevision{}, nil, err
-	}
-
-	s.extendDeadline(120 * time.Second)
-	req := &renterhost.RPCFormContractRequest{
-		Transactions: append(parents, txn),
-		RenterKey:    s.rev.Revision.UnlockConditions.PublicKeys[0],
-	}
-	if err := s.sess.WriteRequest(renterhost.RPCRenewContractID, req); err != nil {
-		return ContractRevision{}, nil, err
-	}
-
-	var resp renterhost.RPCFormContractAdditions
-	if err := s.sess.ReadResponse(&resp, 65536); err != nil {
-		return ContractRevision{}, nil, err
-	}
-
-	// merge host additions with txn
-	txn.SiacoinInputs = append(txn.SiacoinInputs, resp.Inputs...)
-	txn.SiacoinOutputs = append(txn.SiacoinOutputs, resp.Outputs...)
-
-	// sign the txn
-	for _, id := range toSign {
-		txn.TransactionSignatures = append(txn.TransactionSignatures, types.TransactionSignature{
-			ParentID:       id,
-			PublicKeyIndex: 0,
-			CoveredFields:  types.CoveredFields{WholeTransaction: true},
-		})
-	}
-	err = w.SignTransaction(&txn, toSign)
-	if err != nil {
-		err = errors.Wrap(err, "failed to sign transaction")
-		s.sess.WriteResponse(nil, err)
-		return ContractRevision{}, nil, err
-	}
-
-	// calculate signatures added
-	var addedSignatures []types.TransactionSignature
-	for _, sig := range txn.TransactionSignatures {
-		for _, id := range toSign {
-			if id == sig.ParentID {
-				addedSignatures = append(addedSignatures, sig)
-				break
-			}
-		}
-	}
-
-	// create initial (no-op) revision, transaction, and signature
-	initRevision := types.FileContractRevision{
-		ParentID:          txn.FileContractID(0),
-		UnlockConditions:  currentRevision.UnlockConditions,
-		NewRevisionNumber: 1,
-
-		NewFileSize:           fc.FileSize,
-		NewFileMerkleRoot:     fc.FileMerkleRoot,
-		NewWindowStart:        fc.WindowStart,
-		NewWindowEnd:          fc.WindowEnd,
-		NewValidProofOutputs:  fc.ValidProofOutputs,
-		NewMissedProofOutputs: fc.MissedProofOutputs,
-		NewUnlockHash:         fc.UnlockHash,
-	}
-	renterRevisionSig := types.TransactionSignature{
-		ParentID:       crypto.Hash(initRevision.ParentID),
-		CoveredFields:  types.CoveredFields{FileContractRevisions: []uint64{0}},
-		PublicKeyIndex: 0,
-		Signature:      ed25519hash.Sign(s.key, renterhost.HashRevision(initRevision)),
-	}
-
-	// Send signatures.
-	renterSigs := &renterhost.RPCFormContractSignatures{
-		ContractSignatures: addedSignatures,
-		RevisionSignature:  renterRevisionSig,
-	}
-	if err := s.sess.WriteResponse(renterSigs, nil); err != nil {
-		return ContractRevision{}, nil, err
-	}
-
-	// Read the host signatures.
-	var hostSigs renterhost.RPCFormContractSignatures
-	if err := s.sess.ReadResponse(&hostSigs, 4096); err != nil {
-		return ContractRevision{}, nil, err
-	}
-	txn.TransactionSignatures = append(txn.TransactionSignatures, hostSigs.ContractSignatures...)
-	signedTxnSet := append(resp.Parents, append(parents, txn)...)
-
-	return ContractRevision{
-		Revision:   initRevision,
-		Signatures: [2]types.TransactionSignature{renterRevisionSig, hostSigs.RevisionSignature},
-	}, signedTxnSet, nil
-}
-
-// RenewAndClearContract negotiates a new file contract and initial revision for
-// data already stored with a host. The old contract is "cleared," reverting its
-// filesize to zero.
-func (s *Session) RenewAndClearContract(w Wallet, tpool TransactionPool, renterPayout types.Currency, startHeight, endHeight types.BlockHeight) (_ ContractRevision, _ []types.Transaction, err error) {
-	defer wrapErr(&err, "RenewAndClearContract")
 	if endHeight < startHeight {
 		return ContractRevision{}, nil, errors.New("end height must be greater than start height")
 	}

--- a/renter/proto/session_test.go
+++ b/renter/proto/session_test.go
@@ -140,7 +140,7 @@ func TestSession(t *testing.T) {
 	}
 }
 
-func TestRenewAndClear(t *testing.T) {
+func TestRenew(t *testing.T) {
 	renter, host := createTestingPair(t)
 	defer renter.Close()
 	defer host.Close()
@@ -151,7 +151,7 @@ func TestRenewAndClear(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newContract, _, err := renter.RenewAndClearContract(stubWallet{}, stubTpool{}, types.ZeroCurrency, 0, 0)
+	newContract, _, err := renter.RenewContract(stubWallet{}, stubTpool{}, types.ZeroCurrency, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
See #96.

Also removes support for non-clearing renewals. According to SiaStats, 90%+ of hosts now support `RenewAndClear`, so I think this is acceptable.