### PR TITLE
Revert "proto: Add 5% leeway to contract price"

### DIFF
--- a/renter/proto/formcontract.go
+++ b/renter/proto/formcontract.go
@@ -82,13 +82,8 @@ func (s *Session) FormContract(w Wallet, tpool TransactionPool, key ed25519.Priv
 		hostCollateral = types.NewCurrency64(1)
 	}
 
-	// The host adjusts its contract price dynamically based on the current
-	// recommended transaction fee. We don't know how much it will have changed
-	// since we last scanned, but adding 5% leeway seems reasonable.
-	contractPrice := s.host.ContractPrice.MulFloat(1.05)
-
 	// calculate payouts
-	hostPayout := contractPrice.Add(hostCollateral)
+	hostPayout := s.host.ContractPrice.Add(hostCollateral)
 	payout := taxAdjustedPayout(renterPayout.Add(hostPayout))
 
 	// create file contract
@@ -117,14 +112,14 @@ func (s *Session) FormContract(w Wallet, tpool TransactionPool, key ed25519.Priv
 	}
 
 	// Calculate how much the renter needs to pay. On top of the renterPayout,
-	// the renter is responsible for paying the contractPrice, the siafund tax,
-	// and a transaction fee.
+	// the renter is responsible for paying host.ContractPrice, the siafund
+	// tax, and a transaction fee.
 	_, maxFee, err := tpool.FeeEstimate()
 	if err != nil {
 		return ContractRevision{}, nil, errors.Wrap(err, "could not estimate transaction fee")
 	}
 	fee := maxFee.Mul64(estTxnSize)
-	totalCost := renterPayout.Add(contractPrice).Add(types.Tax(startHeight, fc.Payout)).Add(fee)
+	totalCost := renterPayout.Add(s.host.ContractPrice).Add(types.Tax(startHeight, fc.Payout)).Add(fee)
 
 	// create and fund a transaction containing fc
 	txn := types.Transaction{


### PR DESCRIPTION
This reverts commit 0cdccdfff026ade293667f683d39d27d29d95d00. Adding this leeway resulted in contract transactions whose inputs did not equal their outputs.