### PR TITLE
mux: Add renterhost/mux package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	gitlab.com/NebulousLabs/Sia v1.4.8
 	gitlab.com/NebulousLabs/encoding v0.0.0-20200604091946-456c3dc907fe
+	gitlab.com/NebulousLabs/siamux v0.0.0-20200511155832-64a7ac68c8ab // for testing mux compatibility
 	go.etcd.io/bbolt v1.3.5
 	golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5
 	golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/klauspost/reedsolomon v1.9.2 h1:E9CMS2Pqbv+C7tsrYad4YC9MfhnMVWhMRsTi7
 github.com/klauspost/reedsolomon v1.9.2/go.mod h1:CwCi+NUr9pqSVktrkN+Ondf06rkhYZ/pcNv7fu+8Un4=
 github.com/klauspost/reedsolomon v1.9.3 h1:N/VzgeMfHmLc+KHMD1UL/tNkfXAt8FnUqlgXGIduwAY=
 github.com/klauspost/reedsolomon v1.9.3/go.mod h1:CwCi+NUr9pqSVktrkN+Ondf06rkhYZ/pcNv7fu+8Un4=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -101,15 +102,11 @@ gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20190703190009-cb822c37bc94 h1:JJFF
 gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20190703190009-cb822c37bc94/go.mod h1:Lhpa9AcbWcYKcc4amZsOHqJdQglnkWrGuUI68XC7U2Q=
 gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20190814160017-69f300e9bcb8 h1:u74TgFUPYl9G1rYLUKmavwJoF8Li/qJLMSiU5ntafKA=
 gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20190814160017-69f300e9bcb8/go.mod h1:Lhpa9AcbWcYKcc4amZsOHqJdQglnkWrGuUI68XC7U2Q=
-go.etcd.io/bbolt v1.3.4 h1:hi1bXHMVrlQh6WwxAy+qZCV/SYIlqo+Ushwdpa4tAKg=
-go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191105034135-c7e5f84aec59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191107222254-f4817d981bb6/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -134,8 +131,6 @@ golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a h1:i47hUS795cOydZI4AwJQCKXOr4BvxzvikwDoDtHhP2Y=
@@ -146,9 +141,5 @@ golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapK
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-lukechampine.com/frand v1.0.1 h1:awSripFy7kz8l2rV9fCgqNhbdJ6D/LHJwC4NCmJXGMg=
-lukechampine.com/frand v1.0.1/go.mod h1:4S/TM2ZgrKejMcKMbeLjISpJMO+/eZ1zu3vYX9dtj3s=
-lukechampine.com/frand v1.2.0 h1:YjUqUiPtAZxOtK8tru43XUw18JIoZszlupraMSk3aZc=
-lukechampine.com/frand v1.2.0/go.mod h1:4S/TM2ZgrKejMcKMbeLjISpJMO+/eZ1zu3vYX9dtj3s=
 lukechampine.com/frand v1.3.0 h1:HFLrwEHr78+EqAfyp8OChgEzdYCVZzzj6Y+cGDQRhaI=
 lukechampine.com/frand v1.3.0/go.mod h1:4S/TM2ZgrKejMcKMbeLjISpJMO+/eZ1zu3vYX9dtj3s=

--- a/renterhost/mux/encryption.go
+++ b/renterhost/mux/encryption.go
@@ -1,0 +1,196 @@
+package mux
+
+import (
+	"crypto/cipher"
+	"crypto/ed25519"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+
+	"golang.org/x/crypto/blake2b"
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/curve25519"
+	"lukechampine.com/frand"
+)
+
+const (
+	cipherChaCha20Poly1305  = "Chacha20P1305\x00\x00\x00" // padded to 16 bytes
+	chachaPoly1305NonceSize = 12
+	chachaPoly1305TagSize   = 16
+	chachaOverhead          = chachaPoly1305NonceSize + chachaPoly1305TagSize
+)
+
+func generateX25519KeyPair() (xsk, xpk [32]byte) {
+	xsk = frand.Entropy256()
+	pk, _ := curve25519.X25519(xsk[:], curve25519.Basepoint)
+	copy(xpk[:], pk)
+	return
+}
+
+func deriveSharedSecret(xsk, xpk [32]byte) ([32]byte, error) {
+	secret, err := curve25519.X25519(xsk[:], xpk[:])
+	var dst [32]byte
+	copy(dst[:], secret)
+	return dst, err
+}
+
+func encryptInPlace(buf []byte, aead cipher.AEAD) {
+	nonce, plaintext := buf[:chachaPoly1305NonceSize], buf[chachaPoly1305NonceSize:len(buf)-chachaPoly1305TagSize]
+	frand.Read(nonce)
+	aead.Seal(plaintext[:0], nonce, plaintext, nil)
+}
+
+func decryptInPlace(buf []byte, aead cipher.AEAD) ([]byte, error) {
+	nonce, ciphertext := buf[:chachaPoly1305NonceSize], buf[chachaPoly1305NonceSize:]
+	return aead.Open(ciphertext[:0], nonce, ciphertext, nil)
+}
+
+func encryptFrame(buf []byte, h frameHeader, payload []byte, packetSize int, aead cipher.AEAD) []byte {
+	// pad frame to packet boundary
+	numPackets := (encryptedHeaderSize + (len(payload) + chachaOverhead) + (packetSize - 1)) / packetSize
+	frame := buf[:numPackets*packetSize]
+	// encode + encrypt header
+	encodeFrameHeader(frame[chachaPoly1305NonceSize:][:frameHeaderSize], h)
+	encryptInPlace(frame[:encryptedHeaderSize], aead)
+	// pad + encrypt payload
+	copy(frame[encryptedHeaderSize+chachaPoly1305NonceSize:], payload)
+	encryptInPlace(frame[encryptedHeaderSize:], aead)
+	return frame
+}
+
+func decryptFrameHeader(buf []byte, aead cipher.AEAD) (frameHeader, error) {
+	buf, err := decryptInPlace(buf, aead)
+	if err != nil {
+		return frameHeader{}, err
+	}
+	return decodeFrameHeader(buf), nil
+}
+
+func readEncryptedFrame(r io.Reader, buf []byte, packetSize int, aead cipher.AEAD) (frameHeader, []byte, error) {
+	// read, decrypt, and decode header
+	if _, err := io.ReadFull(r, buf[:encryptedHeaderSize]); err != nil {
+		return frameHeader{}, nil, err
+	}
+	h, err := decryptFrameHeader(buf[:encryptedHeaderSize], aead)
+	if err != nil {
+		return frameHeader{}, nil, fmt.Errorf("could not decrypt header: %w", err)
+	}
+	numPackets := (encryptedHeaderSize + (int(h.length) + chachaOverhead) + (packetSize - 1)) / packetSize
+	paddedSize := numPackets*packetSize - encryptedHeaderSize
+	if h.length > uint32(len(buf)) || paddedSize > len(buf) {
+		return frameHeader{}, nil, errors.New("peer sent too-large frame")
+	}
+	// read (padded) payload
+	if _, err := io.ReadFull(r, buf[:paddedSize]); err != nil {
+		return frameHeader{}, nil, err
+	}
+	// decrypt payload
+	payload, err := decryptInPlace(buf[:paddedSize], aead)
+	if err != nil {
+		return frameHeader{}, nil, fmt.Errorf("could not decrypt payload: %w", err)
+	}
+	return h, payload[:h.length], nil
+}
+
+func initiateEncryptionHandshake(conn net.Conn, theirKey ed25519.PublicKey) (cipher.AEAD, error) {
+	xsk, xpk := generateX25519KeyPair()
+
+	// write request
+	buf := make([]byte, 112) // large enough to hold request + response
+	frameBuf := buf[:frameHeaderSize+32+8+16]
+	payload := frameBuf[frameHeaderSize:]
+	encodeFrameHeader(frameBuf, frameHeader{
+		id:     idEstablishEncryption,
+		length: uint32(len(payload)),
+	})
+	copy(payload[:32], xpk[:])
+	binary.LittleEndian.PutUint64(payload[32:], 1) // number of ciphers we're offering
+	copy(payload[40:], cipherChaCha20Poly1305)
+	if _, err := conn.Write(frameBuf); err != nil {
+		return nil, err
+	}
+
+	// read response
+	h, payload, err := readFrame(conn, buf)
+	if err != nil {
+		return nil, err
+	} else if h.id != idEstablishEncryption {
+		return nil, errors.New("invalid handshake ID")
+	} else if h.length < 32+64+16 {
+		return nil, errors.New("handshake payload is too short")
+	} else if string(payload[32+64:]) != cipherChaCha20Poly1305 {
+		return nil, errors.New("invalid cipher selected")
+	}
+	var rxpk [32]byte
+	copy(rxpk[:], payload[:32])
+	sig := payload[32:96]
+
+	// verify signature
+	sigHash := blake2b.Sum256(append(rxpk[:], xpk[:]...))
+	if !ed25519.Verify(theirKey, sigHash[:], sig) {
+		return nil, errors.New("invalid signature")
+	}
+
+	// derive encryption key
+	cipherKey, err := deriveSharedSecret(xsk, rxpk)
+	if err != nil {
+		return nil, err
+	}
+	return chacha20poly1305.New(cipherKey[:])
+}
+
+func acceptEncryptionHandshake(conn net.Conn, ourKey ed25519.PrivateKey) (cipher.AEAD, error) {
+	xsk, xpk := generateX25519KeyPair()
+
+	// read request
+	buf := make([]byte, 1024) // large enough to hold many ciphers
+	h, payload, err := readFrame(conn, buf)
+	if err != nil {
+		return nil, err
+	} else if h.id != idEstablishEncryption {
+		return nil, errors.New("invalid handshake ID")
+	} else if h.length < 8+32+16 {
+		return nil, errors.New("handshake payload is too short")
+	}
+
+	// parse pubkey
+	var rxpk [32]byte
+	copy(rxpk[:], payload[:32])
+	// select cipher
+	numCiphers := binary.LittleEndian.Uint64(payload[32:])
+	if uint64(h.length-40)/16 < numCiphers {
+		return nil, errors.New("invalid cipher encoding")
+	}
+	var supportsChaCha bool
+	for i := uint64(0); i < numCiphers; i++ {
+		supportsChaCha = supportsChaCha || string(payload[40+16*i:][:16]) == cipherChaCha20Poly1305
+	}
+	if !supportsChaCha {
+		return nil, errors.New("no cipher overlap")
+	}
+
+	// write response
+	sigHash := blake2b.Sum256(append(xpk[:], rxpk[:]...))
+	sig := ed25519.Sign(ourKey, sigHash[:])
+	frameBuf := buf[:frameHeaderSize+32+64+16]
+	payload = frameBuf[frameHeaderSize:]
+	encodeFrameHeader(frameBuf, frameHeader{
+		id:     idEstablishEncryption,
+		length: uint32(len(payload)),
+	})
+	copy(payload[:32], xpk[:])
+	copy(payload[32:96], sig)
+	copy(payload[96:], cipherChaCha20Poly1305)
+	if _, err := conn.Write(frameBuf); err != nil {
+		return nil, err
+	}
+
+	// derive encryption key
+	cipherKey, err := deriveSharedSecret(xsk, rxpk)
+	if err != nil {
+		return nil, err
+	}
+	return chacha20poly1305.New(cipherKey[:])
+}

--- a/renterhost/mux/frame.go
+++ b/renterhost/mux/frame.go
@@ -1,0 +1,193 @@
+package mux
+
+import (
+	"crypto/cipher"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	flagFinal = 1 << iota // stream is being closed gracefully
+	flagError             // stream is being closed due to an error
+)
+
+const (
+	idErrorBadInit        = iota // should never be seen
+	idEstablishEncryption        // encryption handshake frame
+	idUpdateSettings             // settings handshake frame
+	idKeepalive                  // empty frame to keep connection open
+)
+
+type frameHeader struct {
+	id     uint32
+	length uint32
+	flags  uint16
+}
+
+const frameHeaderSize = 10
+const encryptedHeaderSize = frameHeaderSize + chachaOverhead
+
+func encodeFrameHeader(buf []byte, h frameHeader) {
+	binary.LittleEndian.PutUint32(buf[0:], h.id)
+	binary.LittleEndian.PutUint32(buf[4:], h.length)
+	binary.LittleEndian.PutUint16(buf[8:], h.flags)
+}
+
+func decodeFrameHeader(buf []byte) (h frameHeader) {
+	h.id = binary.LittleEndian.Uint32(buf[0:])
+	h.length = binary.LittleEndian.Uint32(buf[4:])
+	h.flags = binary.LittleEndian.Uint16(buf[8:])
+	return
+}
+
+func readFrame(r io.Reader, buf []byte) (frameHeader, []byte, error) {
+	// read and decode header
+	if _, err := io.ReadFull(r, buf[:frameHeaderSize]); err != nil {
+		return frameHeader{}, nil, err
+	}
+	h := decodeFrameHeader(buf)
+	if h.length > uint32(len(buf)) {
+		return frameHeader{}, nil, errors.New("peer sent too-large unencrypted frame")
+	}
+	// read payload
+	payload := buf[:h.length]
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return frameHeader{}, nil, err
+	}
+	if h.flags&flagError != 0 {
+		return h, nil, errors.New(string(payload))
+	}
+	return h, payload, nil
+}
+
+func initiateVersionHandshake(conn net.Conn) error {
+	theirVersion := make([]byte, 1)
+	if _, err := conn.Write(ourVersion); err != nil {
+		return fmt.Errorf("could not write our version: %w", err)
+	} else if _, err := io.ReadFull(conn, theirVersion); err != nil {
+		return fmt.Errorf("could not read peer version: %w", err)
+	} else if theirVersion[0] != 1 {
+		return errors.New("bad version")
+	}
+	return nil
+}
+
+func acceptVersionHandshake(conn net.Conn) error {
+	theirVersion := make([]byte, 1)
+	if _, err := io.ReadFull(conn, theirVersion); err != nil {
+		return fmt.Errorf("could not read peer version: %w", err)
+	} else if _, err := conn.Write(ourVersion); err != nil {
+		return fmt.Errorf("could not write our version: %w", err)
+	} else if theirVersion[0] != 1 {
+		return errors.New("bad version")
+	}
+	return nil
+}
+
+type connSettings struct {
+	RequestedPacketSize int
+	MaxFrameSizePackets int
+	MaxTimeout          time.Duration
+}
+
+func (cs connSettings) maxFrameSize() int {
+	return cs.MaxFrameSizePackets * cs.RequestedPacketSize
+}
+
+func (cs connSettings) maxPayloadSize() int {
+	return cs.maxFrameSize() - encryptedHeaderSize - chachaOverhead
+}
+
+const connSettingsSize = 24
+
+func initiateSettingsHandshake(conn net.Conn, ours connSettings, aead cipher.AEAD) (connSettings, error) {
+	// encode + write request
+	frameBuf := make([]byte, ours.RequestedPacketSize)
+	payload := make([]byte, connSettingsSize)
+	binary.LittleEndian.PutUint64(payload[0:], uint64(ours.RequestedPacketSize))
+	binary.LittleEndian.PutUint64(payload[8:], uint64(ours.MaxFrameSizePackets))
+	binary.LittleEndian.PutUint64(payload[16:], uint64(ours.MaxTimeout.Seconds()))
+	frame := encryptFrame(frameBuf, frameHeader{
+		id:     idUpdateSettings,
+		length: uint32(len(payload)),
+	}, payload, ours.RequestedPacketSize, aead)
+	if _, err := conn.Write(frame); err != nil {
+		return connSettings{}, err
+	}
+	// read + decode response
+	h, payload, err := readEncryptedFrame(conn, frameBuf, ours.RequestedPacketSize, aead)
+	if err != nil {
+		return connSettings{}, err
+	} else if h.id != idUpdateSettings {
+		return connSettings{}, errors.New("invalid settings ID")
+	} else if h.length != connSettingsSize {
+		return connSettings{}, errors.New("invalid settings payload")
+	}
+	theirs := connSettings{
+		RequestedPacketSize: int(binary.LittleEndian.Uint64(payload[0:])),
+		MaxFrameSizePackets: int(binary.LittleEndian.Uint64(payload[8:])),
+		MaxTimeout:          time.Second * time.Duration(binary.LittleEndian.Uint64(payload[16:])),
+	}
+	return mergeSettings(ours, theirs)
+}
+
+func acceptSettingsHandshake(conn net.Conn, ours connSettings, aead cipher.AEAD) (connSettings, error) {
+	// read + decode request
+	frameBuf := make([]byte, ours.RequestedPacketSize)
+	h, payload, err := readEncryptedFrame(conn, frameBuf, ours.RequestedPacketSize, aead)
+	if err != nil {
+		return connSettings{}, err
+	} else if h.id != idUpdateSettings {
+		return connSettings{}, errors.New("invalid settings ID")
+	} else if h.length != connSettingsSize {
+		return connSettings{}, errors.New("invalid settings payload")
+	}
+	theirs := connSettings{
+		RequestedPacketSize: int(binary.LittleEndian.Uint64(payload[0:])),
+		MaxFrameSizePackets: int(binary.LittleEndian.Uint64(payload[8:])),
+		MaxTimeout:          time.Second * time.Duration(binary.LittleEndian.Uint64(payload[16:])),
+	}
+	// encode + write response
+	payload = make([]byte, connSettingsSize)
+	binary.LittleEndian.PutUint64(payload[0:], uint64(ours.RequestedPacketSize))
+	binary.LittleEndian.PutUint64(payload[8:], uint64(ours.MaxFrameSizePackets))
+	binary.LittleEndian.PutUint64(payload[16:], uint64(ours.MaxTimeout.Seconds()))
+	frame := encryptFrame(frameBuf, frameHeader{
+		id:     idUpdateSettings,
+		length: uint32(len(payload)),
+	}, payload, ours.RequestedPacketSize, aead)
+	if _, err := conn.Write(frame); err != nil {
+		return connSettings{}, err
+	}
+	return mergeSettings(ours, theirs)
+}
+
+func mergeSettings(ours, theirs connSettings) (connSettings, error) {
+	// use smaller value for all settings
+	merged := ours
+	if theirs.RequestedPacketSize < merged.RequestedPacketSize {
+		merged.RequestedPacketSize = theirs.RequestedPacketSize
+	}
+	if theirs.MaxFrameSizePackets < merged.MaxFrameSizePackets {
+		merged.MaxFrameSizePackets = theirs.MaxFrameSizePackets
+	}
+	if theirs.MaxTimeout < merged.MaxTimeout {
+		merged.MaxTimeout = theirs.MaxTimeout
+	}
+	// enforce minimums and maximums
+	switch {
+	case merged.RequestedPacketSize < 1220:
+		return connSettings{}, errors.New("requested packet size is too small")
+	case merged.MaxFrameSizePackets < 10:
+		return connSettings{}, errors.New("maximum frame size is too small")
+	case merged.MaxFrameSizePackets > 64:
+		return connSettings{}, errors.New("maximum frame size is too large")
+	case merged.MaxTimeout < 2*time.Minute:
+		return connSettings{}, errors.New("maximum timeout is too short")
+	}
+	return merged, nil
+}

--- a/renterhost/mux/mux.go
+++ b/renterhost/mux/mux.go
@@ -1,0 +1,451 @@
+package mux
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var (
+	errClosedConn       = errors.New("underlying connection was closed")
+	errClosedStream     = errors.New("stream was gracefully closed")
+	errPeerClosedStream = errors.New("peer closed stream gracefully")
+	errPeerClosedConn   = errors.New("peer closed underlying connection")
+)
+
+// A Mux multiplexes multiple duplex Streams onto a single net.Conn.
+type Mux struct {
+	conn     net.Conn
+	aead     cipher.AEAD
+	settings connSettings
+
+	cond    sync.Cond // guards + synchronizes subsequent fields
+	streams map[uint32]*Stream
+	nextID  uint32
+	err     error // sticky and fatal
+
+	// fields relating to the pending Write
+	write struct {
+		header   frameHeader
+		payload  []byte
+		timedOut bool
+	}
+}
+
+func (m *Mux) setErr(err error) error {
+	m.cond.L.Lock()
+	defer m.cond.L.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+
+	// try to detect when the peer closed the connection
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.EPROTOTYPE) {
+		err = errPeerClosedConn
+	}
+
+	// set sticky error, close conn, and wake everyone up
+	m.err = err
+	for _, s := range m.streams {
+		s.cond.L.Lock()
+		s.err = err
+		s.cond.Broadcast()
+		s.cond.L.Unlock()
+	}
+	m.conn.Close()
+	m.cond.Broadcast()
+	return err
+}
+
+func (m *Mux) consumeFrame(h frameHeader, payload []byte, deadline time.Time) error {
+	m.cond.L.Lock()
+	defer m.cond.L.Unlock()
+	m.write.timedOut = false
+	if !deadline.IsZero() {
+		if !time.Now().Before(deadline) {
+			return os.ErrDeadlineExceeded
+		}
+		timer := time.AfterFunc(time.Until(deadline), func() {
+			m.cond.L.Lock()
+			m.write.timedOut = true
+			m.cond.Broadcast()
+			m.cond.L.Unlock()
+		})
+		defer timer.Stop()
+	}
+
+	// wait for current frame to be consumed
+	for m.write.header.id != 0 && m.err == nil && !m.write.timedOut {
+		m.cond.Wait()
+	}
+	if m.err != nil {
+		return m.err
+	} else if m.write.timedOut {
+		return os.ErrDeadlineExceeded
+	}
+	// queue our frame and wake the writeLoop
+	//
+	// NOTE: it is not necessary to wait for the actual Write call to complete.
+	// A successful write() syscall doesn't mean that the peer actually received
+	// the data; just that the packets are sitting in a kernel buffer somewhere.
+	// Likewise, (*Stream).Write can return as soon as its frames are buffered.
+	m.write.header = h
+	m.write.payload = payload
+	m.cond.Broadcast()
+	return nil
+}
+
+func (m *Mux) writeLoop() {
+	// wake cond whenever a keepalive is due
+	//
+	// NOTE: we send a keepalive when 75% of the MaxTimeout has elapsed
+	keepaliveInterval := m.settings.MaxTimeout - m.settings.MaxTimeout/4
+	nextKeepalive := time.Now().Add(keepaliveInterval)
+	timer := time.AfterFunc(keepaliveInterval, m.cond.Broadcast) // nice
+	defer timer.Stop()
+
+	writeBuf := make([]byte, m.settings.maxFrameSize())
+	for {
+		// wait for a frame
+		m.cond.L.Lock()
+		for m.write.header.id == 0 && m.err == nil && time.Now().Before(nextKeepalive) {
+			m.cond.Wait()
+		}
+		if m.err != nil {
+			m.cond.L.Unlock()
+			return
+		}
+		// if we have a normal frame, send that; otherwise, send a keepalive
+		h, payload := m.write.header, m.write.payload
+		if h.id == 0 {
+			h, payload = frameHeader{id: idKeepalive}, nil
+		}
+		frame := encryptFrame(writeBuf, h, payload, m.settings.RequestedPacketSize, m.aead)
+		m.cond.L.Unlock()
+
+		// reset keepalive
+		timer.Stop()
+		timer.Reset(keepaliveInterval)
+		nextKeepalive = time.Now().Add(keepaliveInterval)
+
+		// write the frame
+		if _, err := m.conn.Write(frame); err != nil {
+			m.setErr(err)
+			return
+		}
+
+		// clear the payload and wake (*Mux).consumeFrame
+		m.cond.L.Lock()
+		m.write.header = frameHeader{}
+		m.write.payload = nil
+		m.cond.Broadcast()
+		m.cond.L.Unlock()
+	}
+}
+
+func (m *Mux) readLoop() {
+	var curStream *Stream // saves a lock acquisition + map lookup in the common case
+	buf := make([]byte, m.settings.maxFrameSize())
+	for {
+		h, payload, err := readEncryptedFrame(m.conn, buf, m.settings.RequestedPacketSize, m.aead)
+		if err != nil {
+			m.setErr(err)
+			return
+		}
+		switch h.id {
+		case idErrorBadInit, idEstablishEncryption, idUpdateSettings:
+			// peer is behaving weirdly; after initialization, we shouldn't
+			// receive any of these IDs
+			m.setErr(errors.New("peer sent invalid frame ID"))
+			return
+		case idKeepalive:
+			continue // no action required
+		default:
+			// look for matching Stream
+			if curStream == nil || h.id != curStream.id {
+				m.cond.L.Lock()
+				if curStream = m.streams[h.id]; curStream == nil {
+					// no existing stream with this ID; create a new one
+					curStream = &Stream{
+						m:    m,
+						id:   h.id,
+						cond: sync.Cond{L: new(sync.Mutex)},
+					}
+					m.streams[h.id] = curStream
+					m.cond.Broadcast() // wake (*Mux).AcceptStream
+				}
+				m.cond.L.Unlock()
+			}
+			curStream.consumeFrame(h, payload)
+		}
+	}
+}
+
+// Close closes the underlying net.Conn.
+func (m *Mux) Close() error {
+	err := m.setErr(errClosedConn)
+	if err == errClosedConn || err == errPeerClosedConn {
+		err = nil
+	}
+	return err
+}
+
+// AcceptStream waits for and returns the next peer-initiated Stream.
+func (m *Mux) AcceptStream() (*Stream, error) {
+	m.cond.L.Lock()
+	defer m.cond.L.Unlock()
+	for {
+		if m.err != nil {
+			return nil, m.err
+		}
+		for _, s := range m.streams {
+			if !s.accepted {
+				s.accepted = true
+				return s, nil
+			}
+		}
+		m.cond.Wait()
+	}
+}
+
+// DialStream creates a new Stream.
+func (m *Mux) DialStream() (*Stream, error) {
+	m.cond.L.Lock()
+	defer m.cond.L.Unlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	s := &Stream{
+		m:    m,
+		cond: sync.Cond{L: new(sync.Mutex)},
+	}
+	// loop until we find an unused ID
+	//
+	// NOTE: this implementation use alternating IDs for the Dialer and Accepter
+	// to avoid collisions, but other implementations simply choose the ID at
+	// random; thus, we always have to check for collisions.
+again:
+	m.nextID += 2
+	if _, ok := m.streams[m.nextID]; ok {
+		goto again
+	}
+	s.id = m.nextID
+	m.streams[s.id] = s
+	return s, nil
+}
+
+func newMux(conn net.Conn, aead cipher.AEAD, settings connSettings) *Mux {
+	m := &Mux{
+		conn:     conn,
+		aead:     aead,
+		settings: settings,
+		cond:     sync.Cond{L: new(sync.Mutex)},
+		streams:  make(map[uint32]*Stream),
+		nextID:   1 << 8, // avoid collisions with reserved IDs
+	}
+	go m.readLoop()
+	go m.writeLoop()
+	return m
+}
+
+var ourVersion = []byte{1}
+
+var defaultConnSettings = connSettings{
+	RequestedPacketSize: 1440, // IPv6 MTU
+	MaxFrameSizePackets: 10,
+	MaxTimeout:          20 * time.Minute,
+}
+
+// Dial initiates the multiplexer protocol handshake on the provided conn.
+func Dial(conn net.Conn, theirKey ed25519.PublicKey) (*Mux, error) {
+	if err := initiateVersionHandshake(conn); err != nil {
+		return nil, fmt.Errorf("version handshake failed: %w", err)
+	}
+	aead, err := initiateEncryptionHandshake(conn, theirKey)
+	if err != nil {
+		return nil, fmt.Errorf("encryption handshake failed: %w", err)
+	}
+	settings, err := initiateSettingsHandshake(conn, defaultConnSettings, aead)
+	if err != nil {
+		return nil, fmt.Errorf("settings handshake failed: %w", err)
+	}
+	return newMux(conn, aead, settings), nil
+}
+
+// Accept reciprocates a multiplexer protocol handshake on the provided conn.
+func Accept(conn net.Conn, ourKey ed25519.PrivateKey) (*Mux, error) {
+	if err := acceptVersionHandshake(conn); err != nil {
+		return nil, fmt.Errorf("version handshake failed: %w", err)
+	}
+	aead, err := acceptEncryptionHandshake(conn, ourKey)
+	if err != nil {
+		return nil, fmt.Errorf("encryption handshake failed: %w", err)
+	}
+	settings, err := acceptSettingsHandshake(conn, defaultConnSettings, aead)
+	if err != nil {
+		return nil, fmt.Errorf("settings handshake failed: %w", err)
+	}
+	m := newMux(conn, aead, settings)
+	m.nextID++ // avoid collisions with Dialing peer
+	return m, nil
+}
+
+// A Stream is a duplex connection multiplexed over a net.Conn. It implements
+// the net.Conn interface.
+type Stream struct {
+	m        *Mux
+	id       uint32
+	accepted bool
+
+	cond sync.Cond // guards + synchronizes subsequent fields
+	read struct {
+		payload  []byte
+		timedOut bool
+	}
+	err    error
+	rd, wd time.Time // deadlines
+}
+
+// LocalAddr returns the underlying connection's LocalAddr.
+func (s *Stream) LocalAddr() net.Addr { return s.m.conn.LocalAddr() }
+
+// RemoteAddr returns the underlying connection's RemoteAddr.
+func (s *Stream) RemoteAddr() net.Addr { return s.m.conn.RemoteAddr() }
+
+// SetDeadline sets the read and write deadlines associated with the Stream. It
+// is equivalent to calling both SetReadDeadline and SetWriteDeadline.
+//
+// This implementation does not entirely conform to the net.Conn interface.
+// Specifically, setting a new deadline does not affect pending Read or Write
+// calls, only future calls.
+func (s *Stream) SetDeadline(t time.Time) error {
+	s.SetReadDeadline(t)
+	s.SetWriteDeadline(t)
+	return nil
+}
+
+// SetReadDeadline sets the read deadline associated with the Stream.
+//
+// This implementation does not entirely conform to the net.Conn interface.
+// Specifically, setting a new deadline does not affect pending Read calls, only
+// future calls.
+func (s *Stream) SetReadDeadline(t time.Time) error {
+	s.cond.L.Lock()
+	defer s.cond.L.Unlock()
+	s.rd = t
+	return nil
+}
+
+// SetWriteDeadline sets the write deadline associated with the Stream.
+//
+// This implementation does not entirely conform to the net.Conn interface.
+// Specifically, setting a new deadline does not affect pending Write calls,
+// only future calls.
+func (s *Stream) SetWriteDeadline(t time.Time) error {
+	s.cond.L.Lock()
+	defer s.cond.L.Unlock()
+	s.wd = t
+	return nil
+}
+
+func (s *Stream) consumeFrame(h frameHeader, payload []byte) {
+	s.cond.L.Lock()
+	defer s.cond.L.Unlock()
+	if s.err != nil {
+		return
+	}
+	// handle final/error frame
+	if h.flags&flagFinal != 0 {
+		err := errPeerClosedStream
+		if h.flags&flagError != 0 {
+			err = errors.New(string(payload))
+		}
+		s.err = err
+		s.cond.Broadcast() // wake (*Stream).Read
+		return
+	} else if len(payload) == 0 {
+		return
+	}
+	// set payload and wait for it to be consumed
+	s.read.payload = payload
+	s.cond.Broadcast() // wake (*Stream).Read
+	for len(s.read.payload) != 0 && s.err == nil && !s.read.timedOut {
+		s.cond.Wait()
+	}
+}
+
+// Read reads data from the Stream.
+func (s *Stream) Read(p []byte) (int, error) {
+	s.cond.L.Lock()
+	defer s.cond.L.Unlock()
+	s.read.timedOut = false
+	if !s.rd.IsZero() {
+		if !time.Now().Before(s.rd) {
+			return 0, os.ErrDeadlineExceeded
+		}
+		timer := time.AfterFunc(time.Until(s.rd), func() {
+			s.cond.L.Lock()
+			s.read.timedOut = true
+			s.cond.Broadcast()
+			s.cond.L.Unlock()
+		})
+		defer timer.Stop()
+	}
+
+	for len(s.read.payload) == 0 && s.err == nil && !s.read.timedOut {
+		s.cond.Wait()
+	}
+	n := copy(p, s.read.payload)
+	s.read.payload = s.read.payload[n:]
+	s.cond.Broadcast() // wake (*Stream).consumeFrame
+	if s.read.timedOut {
+		return n, os.ErrDeadlineExceeded
+	}
+	return n, s.err
+}
+
+// Write writes data to the Stream.
+func (s *Stream) Write(p []byte) (int, error) {
+	h := frameHeader{id: s.id}
+	buf := bytes.NewBuffer(p)
+	for buf.Len() > 0 {
+		payload := buf.Next(s.m.settings.maxPayloadSize())
+		h.length = uint32(len(payload))
+		if err := s.m.consumeFrame(h, payload, s.wd); err != nil {
+			return len(p) - buf.Len(), err
+		}
+	}
+	return len(p), nil
+}
+
+// Close closes the Stream. The underlying connection is not closed.
+func (s *Stream) Close() error {
+	h := frameHeader{
+		id:    s.id,
+		flags: flagFinal,
+	}
+	err := s.m.consumeFrame(h, nil, s.wd)
+	if err == errPeerClosedStream {
+		err = nil
+	}
+
+	// cancel outstanding Read/Write calls
+	s.cond.L.Lock()
+	defer s.cond.L.Unlock()
+	s.err = errClosedStream
+	s.cond.Broadcast()
+	return err
+}
+
+var _ net.Conn = (*Stream)(nil)

--- a/renterhost/mux/mux_test.go
+++ b/renterhost/mux/mux_test.go
@@ -1,0 +1,724 @@
+package mux
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"gitlab.com/NebulousLabs/Sia/persist"
+	"gitlab.com/NebulousLabs/siamux/mux"
+	"golang.org/x/crypto/chacha20poly1305"
+	"lukechampine.com/frand"
+	"lukechampine.com/us/renterhost"
+)
+
+func TestMux(t *testing.T) {
+	serverKey := ed25519.NewKeyFromSeed(frand.Bytes(ed25519.SeedSize))
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCh := make(chan error, 1)
+	go func() {
+		serverCh <- func() error {
+			conn, err := l.Accept()
+			if err != nil {
+				return err
+			}
+			m, err := Accept(conn, serverKey)
+			if err != nil {
+				return err
+			}
+			defer m.Close()
+			s, err := m.AcceptStream()
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			buf := make([]byte, 13)
+			if _, err := io.ReadFull(s, buf); err != nil {
+				return err
+			}
+			if string(buf) != "hello, world!" {
+				return errors.New("bad hello")
+			}
+			return s.Close()
+		}()
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := Dial(conn, serverKey.Public().(ed25519.PublicKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	s, err := m.DialStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if _, err := s.Write([]byte("hello, world!")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := <-serverCh; err != nil && err != errPeerClosedStream {
+		t.Fatal(err)
+	}
+}
+
+func TestManyStreams(t *testing.T) {
+	serverKey := ed25519.NewKeyFromSeed(frand.Bytes(ed25519.SeedSize))
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCh := make(chan error, 1)
+	go func() {
+		serverCh <- func() error {
+			conn, err := l.Accept()
+			if err != nil {
+				return err
+			}
+			m, err := Accept(conn, serverKey)
+			if err != nil {
+				return err
+			}
+			defer m.Close()
+			for {
+				s, err := m.AcceptStream()
+				if err != nil {
+					return err
+				}
+				// simple echo handler
+				go func() {
+					buf := make([]byte, 100)
+					n, _ := s.Read(buf)
+					s.Write(buf[:n])
+					s.Close()
+				}()
+			}
+		}()
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := Dial(conn, serverKey.Public().(ed25519.PublicKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	// spawn 100 streams
+	var wg sync.WaitGroup
+	errChan := make(chan error, 100)
+	for i := 0; i < cap(errChan); i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s, err := m.DialStream()
+			if err != nil {
+				errChan <- err
+				return
+			}
+			defer s.Close()
+			msg := fmt.Sprintf("hello, %v!", i)
+			buf := make([]byte, len(msg))
+			if _, err := s.Write([]byte(msg)); err != nil {
+				errChan <- err
+			} else if _, err := io.ReadFull(s, buf); err != nil {
+				errChan <- err
+			} else if string(buf) != msg {
+				errChan <- err
+			} else if err := s.Close(); err != nil {
+				errChan <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errChan)
+	for err := range errChan {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := m.Close(); err != nil {
+		t.Fatal(err)
+	} else if err := <-serverCh; err != nil && err != errPeerClosedConn {
+		t.Fatal(err)
+	}
+}
+
+func TestDeadline(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	serverKey := ed25519.NewKeyFromSeed(frand.Bytes(ed25519.SeedSize))
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCh := make(chan error, 1)
+	go func() {
+		serverCh <- func() error {
+			conn, err := l.Accept()
+			if err != nil {
+				return err
+			}
+			m, err := Accept(conn, serverKey)
+			if err != nil {
+				return err
+			}
+			defer m.Close()
+			for {
+				s, err := m.AcceptStream()
+				if err != nil {
+					return err
+				}
+				// wait 100ms before reading/writing
+				buf := make([]byte, 100)
+				time.Sleep(100 * time.Millisecond)
+				if _, err := s.Read(buf); err != nil {
+					return err
+				}
+				time.Sleep(100 * time.Millisecond)
+				if _, err := s.Write([]byte("hello, world!")); err != nil {
+					return err
+				} else if err := s.Close(); err != nil {
+					return err
+				}
+			}
+		}()
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := Dial(conn, serverKey.Public().(ed25519.PublicKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	// a Read deadline should not timeout a Write
+	s, err := m.DialStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := []byte("hello, world!")
+	s.SetReadDeadline(time.Now().Add(time.Millisecond))
+	time.Sleep(2 * time.Millisecond)
+	_, err = s.Write(buf)
+	s.SetReadDeadline(time.Time{})
+	if err != nil {
+		t.Fatal("SetReadDeadline caused Write to fail:", err)
+	} else if _, err := io.ReadFull(s, buf); err != nil {
+		t.Fatal(err)
+	} else if string(buf) != "hello, world!" {
+		t.Fatal("bad echo")
+	} else if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		timeout bool
+		fn      func(*Stream)
+	}{
+		{false, func(*Stream) {}}, // no deadline
+		{false, func(s *Stream) {
+			s.SetDeadline(time.Now().Add(time.Hour)) // plenty of time
+		}},
+		{true, func(s *Stream) {
+			s.SetDeadline(time.Now().Add(time.Millisecond)) // too short
+		}},
+		{true, func(s *Stream) {
+			s.SetDeadline(time.Now().Add(time.Millisecond))
+			s.SetReadDeadline(time.Time{}) // Write should still fail
+		}},
+		{true, func(s *Stream) {
+			s.SetDeadline(time.Now().Add(time.Millisecond))
+			s.SetWriteDeadline(time.Time{}) // Read should still fail
+		}},
+		{false, func(s *Stream) {
+			s.SetDeadline(time.Now())
+			s.SetDeadline(time.Time{}) // should overwrite
+		}},
+		{false, func(s *Stream) {
+			s.SetDeadline(time.Now().Add(time.Millisecond))
+			s.SetWriteDeadline(time.Time{}) // overwrites Read
+			s.SetReadDeadline(time.Time{})  // overwrites Write
+		}},
+	}
+	for i, test := range tests {
+		err := func() error {
+			s, err := m.DialStream()
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			test.fn(s) // set deadlines
+
+			// need to write a fairly large message; otherwise the packets just
+			// get buffered and "succeed" instantly
+			if _, err := s.Write(make([]byte, 1<<20)); err != nil {
+				return err
+			} else if _, err := io.ReadFull(s, buf[:13]); err != nil {
+				return err
+			} else if string(buf) != "hello, world!" {
+				return errors.New("bad echo")
+			}
+			return s.Close()
+		}()
+		if isTimeout := errors.Is(err, os.ErrDeadlineExceeded); test.timeout != isTimeout {
+			t.Errorf("test %v: expected timeout=%v, got %v", i, test.timeout, err)
+		}
+	}
+
+	if err := m.Close(); err != nil {
+		t.Fatal(err)
+	} else if err := <-serverCh; err != nil && err != errPeerClosedConn && err != errPeerClosedStream {
+		t.Fatal(err)
+	}
+}
+
+func TestCompatibility(t *testing.T) {
+	sk, pk := mux.GenerateED25519KeyPair()
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	serverCh := make(chan error, 1)
+	go func() {
+		serverCh <- func() error {
+			conn, err := l.Accept()
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			server, err := mux.NewServerMux(context.Background(), conn, pk, sk, persist.NewLogger(ioutil.Discard), func(*mux.Mux) {}, func(*mux.Mux) {})
+			if err != nil {
+				return err
+			}
+			defer server.Close()
+			s, err := server.AcceptStream()
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			buf := make([]byte, 13)
+			if _, err := io.ReadFull(s, buf); err != nil {
+				return err
+			}
+			if string(buf) != "hello, world!" {
+				return errors.New("bad hello")
+			}
+			return s.Close()
+		}()
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	m, err := Dial(conn, pk[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	s, err := m.DialStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if _, err := s.Write([]byte("hello, world!")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := <-serverCh; err != nil && err != errPeerClosedStream {
+		t.Fatal(err)
+	}
+
+	// reverse roles
+	//
+	// NOTE: new scope, since we're assign different types to same variable names
+	{
+		go func() {
+			serverCh <- func() error {
+				conn, err := l.Accept()
+				if err != nil {
+					return err
+				}
+				server, err := Accept(conn, sk[:])
+				if err != nil {
+					return err
+				}
+				defer server.Close()
+				s, err := server.AcceptStream()
+				if err != nil {
+					return err
+				}
+				defer s.Close()
+				buf := make([]byte, 13)
+				if _, err := io.ReadFull(s, buf); err != nil {
+					return err
+				}
+				if string(buf) != "hello, world!" {
+					return errors.New("bad hello")
+				}
+				return s.Close()
+			}()
+		}()
+
+		conn, err := net.Dial("tcp", l.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close()
+		m, err := mux.NewClientMux(context.Background(), conn, pk, persist.NewLogger(ioutil.Discard), func(*mux.Mux) {}, func(*mux.Mux) {})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer m.Close()
+		s, err := m.NewStream()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+		if _, err := s.Write([]byte("hello, world!")); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := <-serverCh; err != nil && err != errPeerClosedStream {
+			t.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMux(b *testing.B) {
+	serverKey := ed25519.NewKeyFromSeed(frand.Bytes(ed25519.SeedSize))
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer l.Close()
+	serverCh := make(chan error, 1)
+	go func() {
+		serverCh <- func() error {
+			conn, err := l.Accept()
+			if err != nil {
+				return err
+			}
+			m, err := Accept(conn, serverKey)
+			if err != nil {
+				return err
+			}
+			defer m.Close()
+			s, err := m.AcceptStream()
+			if err != nil {
+				return err
+			}
+			io.Copy(ioutil.Discard, s)
+			return s.Close()
+		}()
+	}()
+	defer func() {
+		if err := <-serverCh; err != nil && err != errPeerClosedConn {
+			b.Fatal(err)
+		}
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		b.Fatal(err)
+	}
+	m, err := Dial(conn, serverKey.Public().(ed25519.PublicKey))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer m.Close()
+	s, err := m.DialStream()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer s.Close()
+
+	buf := make([]byte, defaultConnSettings.maxPayloadSize())
+	b.ResetTimer()
+	b.SetBytes(int64(len(buf)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.Write(buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStreams(b *testing.B) {
+	for _, numStreams := range []int{2, 10, 100} {
+		b.Run(fmt.Sprint(numStreams), func(b *testing.B) {
+			serverKey := ed25519.NewKeyFromSeed(frand.Bytes(ed25519.SeedSize))
+			l, err := net.Listen("tcp", ":0")
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer l.Close()
+			serverCh := make(chan error, 1)
+			go func() {
+				serverCh <- func() error {
+					conn, err := l.Accept()
+					if err != nil {
+						return err
+					}
+					m, err := Accept(conn, serverKey)
+					if err != nil {
+						return err
+					}
+					defer m.Close()
+					for {
+						s, err := m.AcceptStream()
+						if err != nil {
+							return err
+						}
+						go func() {
+							io.Copy(ioutil.Discard, s)
+							s.Close()
+						}()
+					}
+				}()
+			}()
+			defer func() {
+				if err := <-serverCh; err != nil && err != errPeerClosedConn {
+					b.Fatal(err)
+				}
+			}()
+
+			conn, err := net.Dial("tcp", l.Addr().String())
+			if err != nil {
+				b.Fatal(err)
+			}
+			m, err := Dial(conn, serverKey.Public().(ed25519.PublicKey))
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer m.Close()
+
+			// open 100 streams in separate goroutines
+			bufSize := defaultConnSettings.maxPayloadSize()
+			buf := make([]byte, bufSize)
+			b.ResetTimer()
+			b.SetBytes(int64(bufSize * numStreams))
+			b.ReportAllocs()
+			var wg sync.WaitGroup
+			wg.Add(numStreams)
+			for j := 0; j < numStreams; j++ {
+				go func() {
+					defer wg.Done()
+					s, err := m.DialStream()
+					if err != nil {
+						panic(err)
+					}
+					defer s.Close()
+					for i := 0; i < b.N; i++ {
+						if _, err := s.Write(buf); err != nil {
+							panic(err)
+						}
+					}
+				}()
+			}
+			wg.Wait()
+		})
+	}
+}
+
+func BenchmarkConn(b *testing.B) {
+	// benchmark throughput of raw TCP conn (plus encryption overhead to make it fair)
+	encryptionKey := frand.Bytes(32)
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	serverCh := make(chan error, 1)
+	go func() {
+		serverCh <- func() error {
+			conn, err := l.Accept()
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			aead, _ := chacha20poly1305.New(encryptionKey)
+			buf := make([]byte, defaultConnSettings.maxFrameSize())
+			for {
+				_, err := io.ReadFull(conn, buf)
+				if err != nil {
+					return err
+				}
+				if _, err := decryptInPlace(buf, aead); err != nil {
+					return err
+				}
+			}
+		}()
+	}()
+	defer func() {
+		if err := <-serverCh; err != nil && err != io.EOF {
+			b.Fatal(err)
+		}
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer conn.Close()
+
+	aead, _ := chacha20poly1305.New(encryptionKey)
+	buf := make([]byte, defaultConnSettings.maxFrameSize())
+	b.ResetTimer()
+	b.SetBytes(int64(defaultConnSettings.maxPayloadSize()))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		encryptInPlace(buf, aead)
+		if _, err := conn.Write(buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSiaMux(b *testing.B) {
+	// create client and server
+	sk, pk := mux.GenerateED25519KeyPair()
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			panic(err)
+		}
+		server, err := mux.NewServerMux(context.Background(), conn, pk, sk, persist.NewLogger(ioutil.Discard), func(*mux.Mux) {}, func(*mux.Mux) {})
+		if err != nil {
+			panic(err)
+		}
+		for {
+			stream, err := server.AcceptStream()
+			if err != nil {
+				return
+			}
+			io.Copy(ioutil.Discard, stream)
+			stream.Close()
+		}
+	}()
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		b.Fatal(err)
+	}
+	client, err := mux.NewClientMux(context.Background(), conn, pk, persist.NewLogger(ioutil.Discard), func(*mux.Mux) {}, func(*mux.Mux) {})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// open a stream
+	stream, err := client.NewStream()
+	if err != nil {
+		b.Fatal(err)
+		return
+	}
+	defer stream.Close()
+
+	msgSize := defaultConnSettings.maxPayloadSize()
+	data := make([]byte, msgSize)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := stream.Write(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRHP2(b *testing.B) {
+	serverKey := ed25519.NewKeyFromSeed(frand.Bytes(ed25519.SeedSize))
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer l.Close()
+	serverCh := make(chan error, 1)
+	go func() {
+		serverCh <- func() error {
+			conn, err := l.Accept()
+			if err != nil {
+				return err
+			}
+			s, err := renterhost.NewHostSession(conn, serverKey)
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			var req renterhost.RPCWriteRequest
+			for i := 0; i < b.N; i++ {
+				if err := s.ReadResponse(&req, math.MaxUint64); err != nil {
+					return err
+				}
+			}
+			return nil
+		}()
+	}()
+	defer func() {
+		if err := <-serverCh; err != nil {
+			b.Log(err)
+		}
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		b.Fatal(err)
+	}
+	s, err := renterhost.NewRenterSession(conn, serverKey.Public().(ed25519.PublicKey))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer s.Close()
+
+	req := &renterhost.RPCWriteRequest{
+		Actions: []renterhost.RPCWriteAction{{
+			Data: make([]byte, defaultConnSettings.maxPayloadSize()),
+		}},
+	}
+	b.ResetTimer()
+	b.SetBytes(int64(len(req.Actions[0].Data)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := s.WriteResponse(req, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This is an implementation of the https://gitlab.com/NebulousLabs/SiaMux multiplexer. It does not handle port mapping, logging, or bandwidth limiting -- just the network protocol. This is the protocol used for RHP3, so we need it in order for the renter to call RHP3 methods.