### PR TITLE
Various mux improvements

### DIFF
--- a/renterhost/mux/frame.go
+++ b/renterhost/mux/frame.go
@@ -64,6 +64,8 @@ func readFrame(r io.Reader, buf []byte) (frameHeader, []byte, error) {
 	return h, payload, nil
 }
 
+var ourVersion = []byte{1}
+
 func initiateVersionHandshake(conn net.Conn) error {
 	theirVersion := make([]byte, 1)
 	if _, err := conn.Write(ourVersion); err != nil {
@@ -103,6 +105,12 @@ func (cs connSettings) maxPayloadSize() int {
 }
 
 const connSettingsSize = 24
+
+var defaultConnSettings = connSettings{
+	RequestedPacketSize: 1440, // IPv6 MTU
+	MaxFrameSizePackets: 10,
+	MaxTimeout:          20 * time.Minute,
+}
 
 func initiateSettingsHandshake(conn net.Conn, ours connSettings, aead cipher.AEAD) (connSettings, error) {
 	// encode + write request

--- a/renterhost/mux/mux_test.go
+++ b/renterhost/mux/mux_test.go
@@ -76,7 +76,7 @@ func TestMux(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := <-serverCh; err != nil && err != errPeerClosedStream {
+	if err := <-serverCh; err != nil && err != ErrPeerClosedStream {
 		t.Fatal(err)
 	}
 }
@@ -161,7 +161,7 @@ func TestManyStreams(t *testing.T) {
 
 	if err := m.Close(); err != nil {
 		t.Fatal(err)
-	} else if err := <-serverCh; err != nil && err != errPeerClosedConn {
+	} else if err := <-serverCh; err != nil && err != ErrPeerClosedConn {
 		t.Fatal(err)
 	}
 }
@@ -295,7 +295,7 @@ func TestDeadline(t *testing.T) {
 
 	if err := m.Close(); err != nil {
 		t.Fatal(err)
-	} else if err := <-serverCh; err != nil && err != errPeerClosedConn && err != errPeerClosedStream {
+	} else if err := <-serverCh; err != nil && err != ErrPeerClosedConn && err != ErrPeerClosedStream {
 		t.Fatal(err)
 	}
 }
@@ -358,7 +358,7 @@ func TestCompatibility(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := <-serverCh; err != nil && err != errPeerClosedStream {
+	if err := <-serverCh; err != nil && err != ErrPeerClosedStream {
 		t.Fatal(err)
 	}
 
@@ -415,7 +415,7 @@ func TestCompatibility(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := <-serverCh; err != nil && err != errPeerClosedStream {
+		if err := <-serverCh; err != nil && err != ErrPeerClosedStream {
 			t.Fatal(err)
 		}
 	}
@@ -449,7 +449,7 @@ func BenchmarkMux(b *testing.B) {
 		}()
 	}()
 	defer func() {
-		if err := <-serverCh; err != nil && err != errPeerClosedConn {
+		if err := <-serverCh; err != nil && err != ErrPeerClosedConn {
 			b.Fatal(err)
 		}
 	}()
@@ -514,7 +514,7 @@ func BenchmarkStreams(b *testing.B) {
 				}()
 			}()
 			defer func() {
-				if err := <-serverCh; err != nil && err != errPeerClosedConn {
+				if err := <-serverCh; err != nil && err != ErrPeerClosedConn {
 					b.Fatal(err)
 				}
 			}()

--- a/renterhost/mux/mux_test.go
+++ b/renterhost/mux/mux_test.go
@@ -470,7 +470,7 @@ func BenchmarkMux(b *testing.B) {
 			}
 			defer m.Close()
 
-			// open 100 streams in separate goroutines
+			// open each stream in a separate goroutine
 			bufSize := defaultConnSettings.maxPayloadSize()
 			buf := make([]byte, bufSize)
 			b.ResetTimer()
@@ -602,7 +602,7 @@ func BenchmarkSiaMux(b *testing.B) {
 			}
 			defer client.Close()
 
-			// open 100 streams in separate goroutines
+			// open each stream in a separate goroutine
 			bufSize := defaultConnSettings.maxPayloadSize()
 			buf := make([]byte, bufSize)
 			b.ResetTimer()

--- a/renterhost/mux/mux_test.go
+++ b/renterhost/mux/mux_test.go
@@ -422,66 +422,7 @@ func TestCompatibility(t *testing.T) {
 }
 
 func BenchmarkMux(b *testing.B) {
-	serverKey := ed25519.NewKeyFromSeed(frand.Bytes(ed25519.SeedSize))
-	l, err := net.Listen("tcp", ":0")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer l.Close()
-	serverCh := make(chan error, 1)
-	go func() {
-		serverCh <- func() error {
-			conn, err := l.Accept()
-			if err != nil {
-				return err
-			}
-			m, err := Accept(conn, serverKey)
-			if err != nil {
-				return err
-			}
-			defer m.Close()
-			s, err := m.AcceptStream()
-			if err != nil {
-				return err
-			}
-			io.Copy(ioutil.Discard, s)
-			return s.Close()
-		}()
-	}()
-	defer func() {
-		if err := <-serverCh; err != nil && err != ErrPeerClosedConn {
-			b.Fatal(err)
-		}
-	}()
-
-	conn, err := net.Dial("tcp", l.Addr().String())
-	if err != nil {
-		b.Fatal(err)
-	}
-	m, err := Dial(conn, serverKey.Public().(ed25519.PublicKey))
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer m.Close()
-	s, err := m.DialStream()
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer s.Close()
-
-	buf := make([]byte, defaultConnSettings.maxPayloadSize())
-	b.ResetTimer()
-	b.SetBytes(int64(len(buf)))
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		if _, err := s.Write(buf); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkStreams(b *testing.B) {
-	for _, numStreams := range []int{2, 10, 100} {
+	for _, numStreams := range []int{1, 2, 10, 100, 500, 1000} {
 		b.Run(fmt.Sprint(numStreams), func(b *testing.B) {
 			serverKey := ed25519.NewKeyFromSeed(frand.Bytes(ed25519.SeedSize))
 			l, err := net.Listen("tcp", ":0")
@@ -535,6 +476,7 @@ func BenchmarkStreams(b *testing.B) {
 			b.ResetTimer()
 			b.SetBytes(int64(bufSize * numStreams))
 			b.ReportAllocs()
+			start := time.Now()
 			var wg sync.WaitGroup
 			wg.Add(numStreams)
 			for j := 0; j < numStreams; j++ {
@@ -553,6 +495,7 @@ func BenchmarkStreams(b *testing.B) {
 				}()
 			}
 			wg.Wait()
+			b.ReportMetric(float64(b.N*numStreams)/time.Since(start).Seconds(), "conns/sec")
 		})
 	}
 }
@@ -611,56 +554,81 @@ func BenchmarkConn(b *testing.B) {
 }
 
 func BenchmarkSiaMux(b *testing.B) {
-	// create client and server
-	sk, pk := mux.GenerateED25519KeyPair()
-	l, err := net.Listen("tcp", ":0")
-	if err != nil {
-		b.Fatal(err)
-	}
-	go func() {
-		conn, err := l.Accept()
-		if err != nil {
-			panic(err)
-		}
-		server, err := mux.NewServerMux(context.Background(), conn, pk, sk, persist.NewLogger(ioutil.Discard), func(*mux.Mux) {}, func(*mux.Mux) {})
-		if err != nil {
-			panic(err)
-		}
-		for {
-			stream, err := server.AcceptStream()
+	for _, numStreams := range []int{1, 2, 10, 100, 500, 1000} {
+		b.Run(fmt.Sprint(numStreams), func(b *testing.B) {
+			sk, pk := mux.GenerateED25519KeyPair()
+			l, err := net.Listen("tcp", ":0")
 			if err != nil {
-				return
+				b.Fatal(err)
 			}
-			io.Copy(ioutil.Discard, stream)
-			stream.Close()
-		}
-	}()
-	conn, err := net.Dial("tcp", l.Addr().String())
-	if err != nil {
-		b.Fatal(err)
-	}
-	client, err := mux.NewClientMux(context.Background(), conn, pk, persist.NewLogger(ioutil.Discard), func(*mux.Mux) {}, func(*mux.Mux) {})
-	if err != nil {
-		b.Fatal(err)
-	}
+			defer l.Close()
+			serverCh := make(chan error, 1)
+			go func() {
+				serverCh <- func() error {
+					conn, err := l.Accept()
+					if err != nil {
+						return err
+					}
+					server, err := mux.NewServerMux(context.Background(), conn, pk, sk, persist.NewLogger(ioutil.Discard), func(*mux.Mux) {}, func(*mux.Mux) {})
+					if err != nil {
+						panic(err)
+					}
+					defer server.Close()
+					for {
+						s, err := server.AcceptStream()
+						if err != nil {
+							return err
+						}
+						go func() {
+							io.Copy(ioutil.Discard, s)
+							s.Close()
+						}()
+					}
+				}()
+			}()
+			defer func() {
+				if err := <-serverCh; err != nil && err != io.EOF {
+					b.Fatal(err)
+				}
+			}()
 
-	// open a stream
-	stream, err := client.NewStream()
-	if err != nil {
-		b.Fatal(err)
-		return
-	}
-	defer stream.Close()
+			conn, err := net.Dial("tcp", l.Addr().String())
+			if err != nil {
+				b.Fatal(err)
+			}
+			client, err := mux.NewClientMux(context.Background(), conn, pk, persist.NewLogger(ioutil.Discard), func(*mux.Mux) {}, func(*mux.Mux) {})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer client.Close()
 
-	msgSize := defaultConnSettings.maxPayloadSize()
-	data := make([]byte, msgSize)
-	b.SetBytes(int64(len(data)))
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		if _, err := stream.Write(data); err != nil {
-			b.Fatal(err)
-		}
+			// open 100 streams in separate goroutines
+			bufSize := defaultConnSettings.maxPayloadSize()
+			buf := make([]byte, bufSize)
+			b.ResetTimer()
+			b.SetBytes(int64(bufSize * numStreams))
+			b.ReportAllocs()
+			start := time.Now()
+			var wg sync.WaitGroup
+			wg.Add(numStreams)
+			for j := 0; j < numStreams; j++ {
+				go func() {
+					defer wg.Done()
+					stream, err := client.NewStream()
+					if err != nil {
+						panic(err)
+					}
+					defer stream.Close()
+					for i := 0; i < b.N; i++ {
+						if _, err := stream.Write(buf); err != nil {
+							panic(err)
+						}
+					}
+				}()
+			}
+			wg.Wait()
+			b.ReportMetric(float64(b.N*numStreams)/time.Since(start).Seconds(), "conns/sec")
+		})
 	}
 }
 


### PR DESCRIPTION
Exported errors, more documentation, and better Write performance with 1000s of streams.

Current benchmarks:

```
BenchmarkConn               15664 ns/op         915.08 MB/s            0 B/op          0 allocs/op

BenchmarkRHP2               21776 ns/op         658.24 MB/s        14482 B/op          4 allocs/op

BenchmarkMux/1              16842 ns/op         851.08 MB/s            0 B/op          0 allocs/op
BenchmarkMux/2              37007 ns/op         774.67 MB/s            0 B/op          0 allocs/op
BenchmarkMux/10            177423 ns/op         807.90 MB/s            7 B/op          0 allocs/op
BenchmarkMux/100          1760469 ns/op         814.21 MB/s          221 B/op          0 allocs/op
BenchmarkMux/500          9458982 ns/op         757.69 MB/s         2814 B/op         22 allocs/op
BenchmarkMux/1000        18073882 ns/op         793.08 MB/s        10215 B/op         84 allocs/op

BenchmarkSiaMux/1           68773 ns/op         208.43 MB/s        87335 B/op         50 allocs/op
BenchmarkSiaMux/2          136385 ns/op         210.20 MB/s       174474 B/op         97 allocs/op
BenchmarkSiaMux/10         704057 ns/op         203.59 MB/s       871841 B/op        480 allocs/op
BenchmarkSiaMux/100       7029083 ns/op         203.92 MB/s      8728755 B/op       4785 allocs/op
BenchmarkSiaMux/500      35327472 ns/op         202.87 MB/s     43966534 B/op      24779 allocs/op
BenchmarkSiaMux/1000     71633701 ns/op         200.10 MB/s     88782438 B/op      51094 allocs/op
```

I also measured some latency quantiles; this is "time to Write ~14KiB:"

```
                           1%         10%         50%           90%        99%
BenchmarkMux/1           6.382µs   11.327µs    33.541µs     61.861µs     68.233µs
BenchmarkMux/2          17.698µs   21.024µs    35.807µs     50.591µs     53.917µs
BenchmarkMux/10        134.394µs   150.35µs   160.259µs    193.652µs    355.255µs
BenchmarkMux/100        15.626µs   280.56µs  1.458045ms   2.635531ms   2.900465ms
BenchmarkMux/500       105.497µs 1.155979ms   6.03254ms  12.819939ms  14.565243ms
BenchmarkMux/1000      113.842µs 2.657014ms 15.162247ms  31.571692ms  36.099315ms

                           1%         10%         50%           90%        99%
BenchmarkSiaMux/1       26.507µs   28.604µs    36.245µs    135.416µs    352.701µs
BenchmarkSiaMux/2       28.572µs   33.507µs    50.256µs    385.124µs    768.357µs
BenchmarkSiaMux/10      31.662µs   45.742µs   509.802µs   1.399073ms   2.449935ms
BenchmarkSiaMux/100     32.176µs   43.799µs  4.441839ms   15.54882ms  28.536804ms
BenchmarkSiaMux/500     35.866µs   48.586µs 20.105927ms  61.639938ms 137.245416ms
BenchmarkSiaMux/1000    37.623µs   50.332µs 42.052932ms 138.548955ms 284.248683ms
```