### PR TITLE
wallet: Add input discarding

### DIFF
--- a/host/contracts.go
+++ b/host/contracts.go
@@ -48,6 +48,7 @@ type contractBuilder struct {
 	settings      hostdb.HostSettings
 	currentHeight types.BlockHeight
 	minFee        types.Currency
+	discard       func() // release txn inputs
 
 	hostAdditions renterhost.RPCFormContractAdditions
 	renterSigs    renterhost.RPCFormContractSignatures
@@ -57,6 +58,12 @@ type contractBuilder struct {
 	finalRevision   types.FileContractRevision
 	renterRenewSigs renterhost.RPCRenewAndClearContractSignatures
 	hostRenewSigs   renterhost.RPCRenewAndClearContractSignatures
+}
+
+func (cb *contractBuilder) cleanup() {
+	if cb.discard != nil {
+		cb.discard()
+	}
 }
 
 func validateFormContract(cb *contractBuilder) error {

--- a/host/host.go
+++ b/host/host.go
@@ -58,7 +58,7 @@ type SectorStore interface {
 // A Wallet provides addresses and funds and signs transactions.
 type Wallet interface {
 	Address() (types.UnlockHash, error)
-	FundTransaction(txn *types.Transaction, cost types.Currency) ([]crypto.Hash, error)
+	FundTransaction(txn *types.Transaction, cost types.Currency) ([]crypto.Hash, func(), error)
 	SignTransaction(txn *types.Transaction, toSign []crypto.Hash) error
 }
 

--- a/host/session.go
+++ b/host/session.go
@@ -272,6 +272,7 @@ func (sh *SessionHandler) rpcFormContract(s *session) error {
 		currentHeight: s.ctx.BlockHeight,
 		minFee:        minFee(sh.tpool),
 	}
+	defer cb.cleanup()
 	if err := validateFormContract(&cb); err != nil {
 		return fmt.Errorf("proposed contract was not acceptable: %w", s.writeError(err))
 	} else if err := fundContractTransaction(&cb, sh.wallet, sh.tpool); err != nil {
@@ -316,6 +317,7 @@ func (sh *SessionHandler) rpcRenewAndClearContract(s *session) error {
 		currentHeight: sh.contracts.Height(),
 		minFee:        minFee(sh.tpool),
 	}
+	defer cb.cleanup()
 	if err := validateFinalRevision(&cb, s.ctx.Contract, req.FinalValidProofValues, req.FinalMissedProofValues); err != nil {
 		return s.writeError(err)
 	} else if err := validateRenewContract(&cb, s.ctx.Contract); err != nil {

--- a/host/session_test.go
+++ b/host/session_test.go
@@ -15,8 +15,8 @@ import (
 type stubWallet struct{}
 
 func (stubWallet) Address() (_ types.UnlockHash, _ error) { return }
-func (stubWallet) FundTransaction(*types.Transaction, types.Currency) (_ []crypto.Hash, _ error) {
-	return
+func (stubWallet) FundTransaction(*types.Transaction, types.Currency) ([]crypto.Hash, func(), error) {
+	return nil, func() {}, nil
 }
 func (stubWallet) SignTransaction(txn *types.Transaction, toSign []crypto.Hash) error {
 	txn.TransactionSignatures = append(txn.TransactionSignatures, make([]types.TransactionSignature, len(toSign))...)

--- a/renter/proto/formcontract.go
+++ b/renter/proto/formcontract.go
@@ -116,10 +116,11 @@ func (s *Session) FormContract(w Wallet, tpool TransactionPool, key ed25519.Priv
 	if !fee.IsZero() {
 		txn.MinerFees = append(txn.MinerFees, fee)
 	}
-	toSign, err := w.FundTransaction(&txn, totalCost)
+	toSign, discard, err := w.FundTransaction(&txn, totalCost)
 	if err != nil {
 		return ContractRevision{}, nil, err
 	}
+	defer discard()
 	// the host expects the contract to have no TransactionSignatures
 	addedSignatures := txn.TransactionSignatures
 	txn.TransactionSignatures = nil

--- a/renter/proto/renew.go
+++ b/renter/proto/renew.go
@@ -126,10 +126,11 @@ func (s *Session) RenewContract(w Wallet, tpool TransactionPool, renterPayout ty
 	if !fee.IsZero() {
 		txn.MinerFees = append(txn.MinerFees, fee)
 	}
-	toSign, err := w.FundTransaction(&txn, renterCost)
+	toSign, discard, err := w.FundTransaction(&txn, renterCost)
 	if err != nil {
 		return ContractRevision{}, nil, err
 	}
+	defer discard()
 	// the host expects the contract to have no TransactionSignatures
 	addedSignatures := txn.TransactionSignatures
 	txn.TransactionSignatures = nil

--- a/renter/proto/session_test.go
+++ b/renter/proto/session_test.go
@@ -21,8 +21,8 @@ func deepEqual(a, b interface{}) bool {
 type stubWallet struct{}
 
 func (stubWallet) Address() (_ types.UnlockHash, _ error) { return }
-func (stubWallet) FundTransaction(*types.Transaction, types.Currency) (_ []crypto.Hash, _ error) {
-	return
+func (stubWallet) FundTransaction(*types.Transaction, types.Currency) ([]crypto.Hash, func(), error) {
+	return nil, func() {}, nil
 }
 func (stubWallet) SignTransaction(txn *types.Transaction, toSign []crypto.Hash) error {
 	txn.TransactionSignatures = append(txn.TransactionSignatures, make([]types.TransactionSignature, len(toSign))...)

--- a/renter/renterutil/filesystem_test.go
+++ b/renter/renterutil/filesystem_test.go
@@ -23,8 +23,8 @@ import (
 type stubWallet struct{}
 
 func (stubWallet) Address() (_ types.UnlockHash, _ error) { return }
-func (stubWallet) FundTransaction(*types.Transaction, types.Currency) (_ []crypto.Hash, _ error) {
-	return
+func (stubWallet) FundTransaction(*types.Transaction, types.Currency) ([]crypto.Hash, func(), error) {
+	return nil, func() {}, nil
 }
 func (stubWallet) SignTransaction(txn *types.Transaction, toSign []crypto.Hash) error {
 	txn.TransactionSignatures = append(txn.TransactionSignatures, make([]types.TransactionSignature, len(toSign))...)


### PR DESCRIPTION
This prevents races between multiple consumers of `proto.Wallet`/`host.Wallet` that are constructing transactions. Previously, the following situation could arise:

- Goroutine A calls `FundTransaction`, which returns a transaction spending input X
- Goroutine B calls `FundTransaction`, which returns a transaction spending inputs X Y Z
- Goroutine A broadcasts its transaction successfully
- Goroutine B broadcasts its transaction, but the transaction is rejected because it double-spends X

In `muse` I worked around this by guarding calls to `FormContract`/`RenewContract` with a lock, but this had the unfortunate side effect of serializing all contract formation/renewal.

The new API requires consumers to explicitly discard inputs when they are finished with them. Consequently, `FundTransaction` can track (and ignore) which inputs are available and which inputs have been "claimed" by other consumers. This matches the API of the `siad` wallet.

`HotWallet` has been updated to satisfy the new `FundTransaction` method signature. A corresponding change will need to be made to the `walrus` client API.