### PR TITLE
ed25519hash: Add batch verification

### DIFF
--- a/ed25519hash/batch.go
+++ b/ed25519hash/batch.go
@@ -1,0 +1,163 @@
+package ed25519hash
+
+import (
+	"crypto/ed25519"
+	"crypto/sha512"
+
+	"filippo.io/edwards25519"
+	"lukechampine.com/frand"
+)
+
+// VerifyBatch verifies a set of signatures. This provides a speedup of roughly
+// 2x compared to verifying the signatures individually. However, if
+// verification fails, the caller cannot determine which signatures were invalid
+// without resorting to individual verification.
+func VerifyBatch(keys []ed25519.PublicKey, hashes [][32]byte, sigs [][]byte) bool {
+	// The batch verification equation from the original Ed25519 paper is:
+	//
+	//   [-sum(z_i * s_i)]B + sum([z_i]R_i) + sum([z_i * k_i]A_i) = 0
+	//
+	// where:
+	// - A_i is the verification key;
+	// - R_i is the signature's R value;
+	// - s_i is the signature's s value;
+	// - k_i is the hash of the message and other data;
+	// - z_i is a random 128-bit scalar.
+	//
+	// However, this can produce inconsistent results in the presence of
+	// adversarial signatures (signatures with nonzero torsion components). To
+	// guard against this, we multiply the whole equation by the cofactor. See
+	// https://hdevalence.ca/blog/2020-10-04-its-25519am for more details.
+
+	// save some heap allocations by allocating all scalar and point values
+	// together
+	svals := make([]edwards25519.Scalar, 1+len(sigs)+len(keys))
+	pvals := make([]edwards25519.Point, 1+len(sigs)+len(keys))
+
+	scalars := make([]*edwards25519.Scalar, 1+len(sigs)+len(keys))
+	for i := range scalars {
+		scalars[i] = &svals[i]
+	}
+	Bcoeff := scalars[0]               // z_i * s_i
+	Rcoeffs := scalars[1:][:len(sigs)] // z_i
+	Acoeffs := scalars[1+len(sigs):]   // z_i * k_i
+
+	points := make([]*edwards25519.Point, 1+len(keys)+len(sigs))
+	for i := range points {
+		points[i] = &pvals[i]
+	}
+	points[0].Set(edwards25519.NewGeneratorPoint())
+	Rs := points[1:][:len(sigs)]
+	As := points[1+len(sigs):]
+
+	for i := range sigs {
+		pub := keys[i]
+		hash := hashes[i]
+		sig := sigs[i]
+
+		// decompress A
+		if l := len(pub); l != ed25519.PublicKeySize {
+			return false
+		} else if _, err := As[i].SetBytes(pub); err != nil {
+			return false
+		}
+
+		// decompress R
+		if len(sig) != ed25519.SignatureSize || sig[63]&224 != 0 {
+			return false
+		} else if _, err := Rs[i].SetBytes(sig[:32]); err != nil {
+			return false
+		}
+
+		// generate z
+		buf := make([]byte, 96)
+		frand.Read(buf[:16])
+		z, _ := Rcoeffs[i].SetCanonicalBytes(buf[:32])
+
+		// decode s
+		s, err := new(edwards25519.Scalar).SetCanonicalBytes(sig[32:])
+		if err != nil {
+			return false
+		}
+		Bcoeff.MultiplyAdd(s, z, Bcoeff)
+
+		// compute k
+		copy(buf[:32], sig[:32])
+		copy(buf[32:], pub)
+		copy(buf[64:], hash[:])
+		hramDigest := sha512.Sum512(buf)
+		k := Acoeffs[i].SetUniformBytes(hramDigest[:])
+		Acoeffs[i] = k.Multiply(k, z)
+	}
+	Bcoeff.Negate(Bcoeff) // this term is negative
+
+	// multiply each point by its scalar coefficient, and sum the products
+	check := new(edwards25519.Point).VarTimeMultiScalarMult(scalars, points)
+	check.MultByCofactor(check)
+	return check.Equal(edwards25519.NewIdentityPoint()) == 1
+}
+
+// VerifySingleKeyBatch verifies a set of signatures that were all produced by
+// the same key. This provides a speedup of roughly 4x compared to verifying the
+// signatures individually. However, if verification fails, the caller cannot
+// determine which signatures were invalid without resorting to individual
+// verification.
+func VerifySingleKeyBatch(pub ed25519.PublicKey, hashes [][32]byte, sigs [][]byte) bool {
+	// Since we only have one A point, we can accumulate all of its coefficients
+	// together. That is, instead of:
+	//
+	//   sum([z_i * k_i]A_i)
+	//
+	// we compute:
+	//
+	//   [sum(z_i * k_i)]A_i
+
+	svals := make([]edwards25519.Scalar, 1+len(sigs)+1)
+	pvals := make([]edwards25519.Point, 1+len(sigs)+1)
+	scalars := make([]*edwards25519.Scalar, 1+len(sigs)+1)
+	for i := range scalars {
+		scalars[i] = &svals[i]
+	}
+	Bcoeff := scalars[0]
+	Rcoeffs := scalars[1:][:len(sigs)]
+	Acoeff := scalars[1+len(sigs)]
+	points := make([]*edwards25519.Point, 1+len(sigs)+1)
+	for i := range points {
+		points[i] = &pvals[i]
+	}
+	points[0].Set(edwards25519.NewGeneratorPoint())
+	Rs := points[1:][:len(sigs)]
+	A := points[1+len(sigs)]
+	if l := len(pub); l != ed25519.PublicKeySize {
+		return false
+	} else if _, err := A.SetBytes(pub); err != nil {
+		return false
+	}
+	for i := range sigs {
+		hash := hashes[i]
+		sig := sigs[i]
+		if len(sig) != ed25519.SignatureSize || sig[63]&224 != 0 {
+			return false
+		} else if _, err := Rs[i].SetBytes(sig[:32]); err != nil {
+			return false
+		}
+		buf := make([]byte, 96)
+		frand.Read(buf[:16])
+		z, _ := Rcoeffs[i].SetCanonicalBytes(buf[:32])
+		s, err := new(edwards25519.Scalar).SetCanonicalBytes(sig[32:])
+		if err != nil {
+			return false
+		}
+		Bcoeff.MultiplyAdd(s, z, Bcoeff)
+		copy(buf[:32], sig[:32])
+		copy(buf[32:], pub)
+		copy(buf[64:], hash[:])
+		hramDigest := sha512.Sum512(buf)
+		k := new(edwards25519.Scalar).SetUniformBytes(hramDigest[:])
+		Acoeff.MultiplyAdd(k, z, Acoeff)
+	}
+	Bcoeff.Negate(Bcoeff)
+	check := new(edwards25519.Point).VarTimeMultiScalarMult(scalars, points)
+	check.MultByCofactor(check)
+	return check.Equal(edwards25519.NewIdentityPoint()) == 1
+}

--- a/ed25519hash/batch_test.go
+++ b/ed25519hash/batch_test.go
@@ -1,0 +1,119 @@
+package ed25519hash
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"testing"
+
+	"lukechampine.com/frand"
+)
+
+func TestVerifyBatch(t *testing.T) {
+	keys := make([]ed25519.PublicKey, 10)
+	hashes := make([][32]byte, len(keys))
+	sigs := make([][]byte, len(keys))
+	for i := range keys {
+		pub, priv, _ := ed25519.GenerateKey(nil)
+		keys[i] = pub
+		hashes[i] = frand.Entropy256()
+		sigs[i] = Sign(priv, hashes[i])
+		if !Verify(pub, hashes[i], sigs[i]) {
+			t.Fatal("individual sig failed verification")
+		}
+	}
+	if !VerifyBatch(keys, hashes, sigs) {
+		t.Fatal("signature set failed batch verification")
+	}
+
+	// corrupt one key/hash/sig and check that verification fails
+	keys[0][0] ^= 1
+	if VerifyBatch(keys, hashes, sigs) {
+		t.Error("corrupted key passed batch verification")
+	}
+	keys[0][0] ^= 1
+	hashes[0][0] ^= 1
+	if VerifyBatch(keys, hashes, sigs) {
+		t.Error("corrupted hash passed batch verification")
+	}
+	hashes[0][0] ^= 1
+	sigs[0][0] ^= 1
+	if VerifyBatch(keys, hashes, sigs) {
+		t.Error("corrupted sig passed batch verification")
+	}
+}
+
+func TestVerifySingleKeyBatch(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	hashes := make([][32]byte, 10)
+	sigs := make([][]byte, len(hashes))
+	for i := range sigs {
+		hashes[i] = frand.Entropy256()
+		sigs[i] = Sign(priv, hashes[i])
+		if !Verify(pub, hashes[i], sigs[i]) {
+			t.Fatal("individual sig failed verification")
+		}
+	}
+	if !VerifySingleKeyBatch(pub, hashes, sigs) {
+		t.Fatal("signature set failed batch verification")
+	}
+
+	// corrupt key/hash/sig and check that verification fails
+	pub[0] ^= 1
+	if VerifySingleKeyBatch(pub, hashes, sigs) {
+		t.Error("corrupted key passed batch verification")
+	}
+	pub[0] ^= 1
+	hashes[0][0] ^= 1
+	if VerifySingleKeyBatch(pub, hashes, sigs) {
+		t.Error("corrupted hash passed batch verification")
+	}
+	hashes[0][0] ^= 1
+	sigs[0][0] ^= 1
+	if VerifySingleKeyBatch(pub, hashes, sigs) {
+		t.Error("corrupted sig passed batch verification")
+	}
+}
+
+func BenchmarkVerifyBatch(b *testing.B) {
+	for _, n := range []int{1, 8, 64, 1024} {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			b.ReportAllocs()
+			keys := make([]ed25519.PublicKey, n)
+			hashes := make([][32]byte, len(keys))
+			sigs := make([][]byte, len(keys))
+			for i := range keys {
+				pub, priv, _ := ed25519.GenerateKey(nil)
+				keys[i] = pub
+				hashes[i] = frand.Entropy256()
+				sigs[i] = Sign(priv, hashes[i])
+			}
+			// NOTE: dividing by n so that metrics are per-signature
+			for i := 0; i < b.N/n; i++ {
+				if !VerifyBatch(keys, hashes, sigs) {
+					b.Fatal("signature set failed batch verification")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkVerifySingleKeyBatch(b *testing.B) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	for _, n := range []int{1, 8, 64, 1024} {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			b.ReportAllocs()
+			hashes := make([][32]byte, n)
+			sigs := make([][]byte, n)
+			for i := range sigs {
+				hashes[i] = frand.Entropy256()
+				sigs[i] = Sign(priv, hashes[i])
+			}
+			// NOTE: dividing by n so that metrics are per-signature
+			for i := 0; i < b.N/n; i++ {
+				if !VerifySingleKeyBatch(pub, hashes, sigs) {
+					b.Fatal("signature set failed batch verification")
+				}
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module lukechampine.com/us
 go 1.13
 
 require (
-	filippo.io/edwards25519 v1.0.0-alpha.2
+	filippo.io/edwards25519 v1.0.0-beta.2
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da
 	github.com/pkg/errors v0.9.1
 	gitlab.com/NebulousLabs/Sia v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 filippo.io/edwards25519 v1.0.0-alpha.2 h1:EWbZLqGEPSIj2W69gx04KtNVkyPIfe3uj0DhDQJonbQ=
 filippo.io/edwards25519 v1.0.0-alpha.2/go.mod h1:X+pm78QAUPtFLi1z9PYIlS/bdDnvbCOGKtZ+ACWEf7o=
+filippo.io/edwards25519 v1.0.0-beta.2 h1:/BZRNzm8N4K4eWfK28dL4yescorxtO7YG1yun8fy+pI=
+filippo.io/edwards25519 v1.0.0-beta.2/go.mod h1:X+pm78QAUPtFLi1z9PYIlS/bdDnvbCOGKtZ+ACWEf7o=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
This isn't directly useful for anything in `us` (yet), but in theory it could be used in `Sia/types` to validate transactions a bit faster. More likely, we'll just switch to using `ed25519consensus` in a subsequent hardfork.