### PR TITLE
Use SerialBlobUploader and SerialBlobDownloader if P = 1

### DIFF
--- a/renter/renterutil/kv.go
+++ b/renter/renterutil/kv.go
@@ -32,11 +32,20 @@ func (kv PseudoKV) Put(ctx context.Context, key []byte, r io.Reader) error {
 	if err := kv.DB.AddBlob(b); err != nil {
 		return err
 	}
-	bu := ParallelBlobUploader{
-		U: kv.Uploader,
-		M: kv.M,
-		N: kv.N,
-		P: kv.P,
+	var bu BlobUploader
+	if kv.P == 1 {
+		bu = SerialBlobUploader{
+			U: kv.Uploader,
+			M: kv.M,
+			N: kv.N,
+		}
+	} else {
+		bu = ParallelBlobUploader{
+			U: kv.Uploader,
+			M: kv.M,
+			N: kv.N,
+			P: kv.P,
+		}
 	}
 	return bu.UploadBlob(ctx, kv.DB, b, r)
 }

--- a/renter/renterutil/kv.go
+++ b/renter/renterutil/kv.go
@@ -100,9 +100,16 @@ func (kv PseudoKV) GetRange(ctx context.Context, key []byte, w io.Writer, off, n
 	if err != nil {
 		return err
 	}
-	bd := ParallelBlobDownloader{
-		D: kv.Downloader,
-		P: kv.P,
+	var bd BlobDownloader
+	if kv.P == 1 {
+		bd = SerialBlobDownloader{
+			D: kv.Downloader,
+		}
+	} else {
+		bd = ParallelBlobDownloader{
+			D: kv.Downloader,
+			P: kv.P,
+		}
 	}
 	return bd.DownloadBlob(ctx, kv.DB, b, w, off, n)
 }


### PR DESCRIPTION
Currently, PseudoKV always uses ParallelBlobUploader and ParallelBlobDownloader, but I think it's better to use SerialBlobUploader and SerialBlobDownloader if P = 1. 