### PR TITLE
DeleteSectors ignores "could not find the desired sector"

### DIFF
--- a/renter/renterutil/strategies.go
+++ b/renter/renterutil/strategies.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"gitlab.com/NebulousLabs/Sia/crypto"
+	"gitlab.com/NebulousLabs/Sia/modules/host/contractmanager"
 	"lukechampine.com/frand"
 	"lukechampine.com/us/hostdb"
 	"lukechampine.com/us/merkle"
@@ -1306,7 +1307,7 @@ func (ssd SerialSectorDeleter) DeleteSectors(ctx context.Context, db MetaDB, sec
 		// TODO: respect ctx
 		err = h.DeleteSectors(roots)
 		ssd.Hosts.release(hostKey)
-		if err != nil {
+		if err != nil && !errors.Is(err, contractmanager.ErrSectorNotFound) {
 			return err
 		}
 		// TODO: mark sectors as deleted in db
@@ -1333,7 +1334,7 @@ func (psd ParallelSectorDeleter) DeleteSectors(ctx context.Context, db MetaDB, s
 				// TODO: respect ctx
 				err = h.DeleteSectors(roots)
 				psd.Hosts.release(hostKey)
-				if err != nil {
+				if err != nil && !errors.Is(err, contractmanager.ErrSectorNotFound) {
 					return &HostError{hostKey, err}
 				}
 				// TODO: mark sectors as deleted in db


### PR DESCRIPTION
That error means the sector is already removed, and we can ignore it. 

Callers of `ParallelSectorDeleter.DeleteSectors` are also able to ignore the error. However, it's not easy to ignore a certain error from `HostErrorSet`. I thus think it's better `ParallelSectorDeleter.DeleteSectors` ignores it.