### PR TITLE
Export private errors in renterutil package

### DIFF
--- a/renter/renterutil/fileops.go
+++ b/renter/renterutil/fileops.go
@@ -418,7 +418,7 @@ func (fs *PseudoFS) fileReadAt(f *openMetaFile, p []byte, off int64) (int, error
 			for req := range reqChan {
 				hostKey := f.m.Hosts[req.shardIndex]
 				s, err := fs.hosts.tryAcquire(hostKey)
-				if err == errHostAcquired && req.block {
+				if err == ErrHostAcquired && req.block {
 					s, err = fs.hosts.acquire(hostKey)
 				}
 				if err != nil {
@@ -451,7 +451,7 @@ func (fs *PseudoFS) fileReadAt(f *openMetaFile, p []byte, off int64) (int, error
 		if err == nil {
 			goodShards++
 		} else {
-			if err.Err == errHostAcquired {
+			if err.Err == ErrHostAcquired {
 				// host could not be acquired without blocking; add it to the back
 				// of the queue, but next time, block
 				reqQueue = append(reqQueue, req{

--- a/renter/renterutil/hostset.go
+++ b/renter/renterutil/hostset.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	errNoHost        = errors.New("no record of that host")
-	errHostAcquired  = errors.New("host is currently acquired")
-	errHostSetClosed = errors.New("host set closed")
+	ErrNoHost        = errors.New("no record of that host")
+	ErrHostAcquired  = errors.New("host is currently acquired")
+	ErrHostSetClosed = errors.New("host set closed")
 )
 
 // A HostError associates an error with a given host.
@@ -98,7 +98,7 @@ func (set *HostSet) HasHost(hostKey hostdb.HostPublicKey) bool {
 	return ok
 }
 
-func reconnectAfterClose() error { return errHostSetClosed }
+func reconnectAfterClose() error { return ErrHostSetClosed }
 
 // Close closes all of the sessions in the set.
 func (set *HostSet) Close() error {
@@ -118,7 +118,7 @@ func (set *HostSet) Close() error {
 func (set *HostSet) acquire(host hostdb.HostPublicKey) (*proto.Session, error) {
 	ls, ok := set.sessions[host]
 	if !ok {
-		return nil, errNoHost
+		return nil, ErrNoHost
 	}
 	ls.mu.Lock()
 	if err := ls.reconnect(); err != nil {
@@ -131,10 +131,10 @@ func (set *HostSet) acquire(host hostdb.HostPublicKey) (*proto.Session, error) {
 func (set *HostSet) tryAcquire(host hostdb.HostPublicKey) (*proto.Session, error) {
 	ls, ok := set.sessions[host]
 	if !ok {
-		return nil, errNoHost
+		return nil, ErrNoHost
 	}
 	if !ls.mu.TryLock() {
-		return nil, errHostAcquired
+		return nil, ErrHostAcquired
 	}
 	if err := ls.reconnect(); err != nil {
 		ls.mu.Unlock()

--- a/renter/renterutil/kv.go
+++ b/renter/renterutil/kv.go
@@ -274,7 +274,7 @@ func (sbb *SmallBlobBuffer) Upload(ctx context.Context, hosts *HostSet) error {
 			defer wg.Done()
 			for req := range reqChan {
 				sess, err := hosts.tryAcquire(req.hostKey)
-				if err == errHostAcquired && req.block {
+				if err == ErrHostAcquired && req.block {
 					sess, err = hosts.acquire(req.hostKey)
 				}
 				if err != nil {
@@ -318,7 +318,7 @@ func (sbb *SmallBlobBuffer) Upload(ctx context.Context, hosts *HostSet) error {
 			finalHosts[resp.req.shardIndex] = resp.req.hostKey
 			rem--
 		} else {
-			if resp.err == errHostAcquired {
+			if resp.err == ErrHostAcquired {
 				// host could not be acquired without blocking; add it to the back
 				// of the queue, but next time, block
 				resp.req.block = true

--- a/renter/renterutil/strategies.go
+++ b/renter/renterutil/strategies.go
@@ -31,7 +31,7 @@ func acquireCtx(ctx context.Context, hosts *HostSet, hostKey hostdb.HostPublicKe
 	done := make(chan struct{})
 	go func() {
 		sess, err = hosts.tryAcquire(hostKey)
-		if err == errHostAcquired && block {
+		if err == ErrHostAcquired && block {
 			sess, err = hosts.acquire(hostKey)
 		}
 		select {
@@ -326,7 +326,7 @@ func (pcu ParallelChunkUploader) UploadChunk(ctx context.Context, db MetaDB, c D
 			}
 			rem--
 		} else {
-			if resp.err == errHostAcquired {
+			if resp.err == ErrHostAcquired {
 				// host could not be acquired without blocking; add it to the back
 				// of the queue, but next time, block
 				resp.req.block = true
@@ -575,7 +575,7 @@ func (ocu OverdriveChunkUploader) UploadChunk(ctx context.Context, db MetaDB, c 
 			rem--
 			success[resp.req.shardIndex] = true
 		} else {
-			if resp.err == errHostAcquired {
+			if resp.err == ErrHostAcquired {
 				// host could not be acquired without blocking; add it to the back
 				// of the queue, but next time, block
 				resp.req.block = true
@@ -727,7 +727,7 @@ func (pcd ParallelChunkDownloader) DownloadChunk(ctx context.Context, db MetaDB,
 		if resp.err == nil {
 			goodShards++
 		} else {
-			if resp.err.Err == errHostAcquired {
+			if resp.err.Err == ErrHostAcquired {
 				// host could not be acquired without blocking; add it to the back
 				// of the queue, but next time, block
 				reqQueue = append(reqQueue, req{
@@ -847,7 +847,7 @@ func (ocd OverdriveChunkDownloader) DownloadChunk(ctx context.Context, db MetaDB
 			goodShards++
 			shards[resp.req.shardIndex] = resp.shard
 		} else {
-			if resp.err.Err == errHostAcquired {
+			if resp.err.Err == ErrHostAcquired {
 				// host could not be acquired without blocking; add it to the back
 				// of the queue, but next time, block
 				resp.req.block = true


### PR DESCRIPTION
Since we need to know which error is returned, this PR exports those errors.