### PR TITLE
fix invalid signature when using SiadClient

### DIFF
--- a/renter/proto/formcontract.go
+++ b/renter/proto/formcontract.go
@@ -183,7 +183,7 @@ func (s *Session) FormContract(w Wallet, tpool TransactionPool, key ed25519.Priv
 
 	// Send signatures.
 	renterSigs := &renterhost.RPCFormContractSignatures{
-		ContractSignatures: addedSignatures,
+		ContractSignatures: txn.TransactionSignatures,
 		RevisionSignature:  renterRevisionSig,
 	}
 	if err := s.sess.WriteResponse(renterSigs, nil); err != nil {

--- a/renter/proto/renew.go
+++ b/renter/proto/renew.go
@@ -206,7 +206,7 @@ func (s *Session) RenewContract(w Wallet, tpool TransactionPool, renterPayout ty
 
 	// Send signatures.
 	renterSigs := &renterhost.RPCRenewAndClearContractSignatures{
-		ContractSignatures:     addedSignatures,
+		ContractSignatures:     txn.TransactionSignatures,
 		RevisionSignature:      renterRevisionSig,
 		FinalRevisionSignature: ed25519hash.Sign(s.key, renterhost.HashRevision(finalOldRevision)),
 	}


### PR DESCRIPTION
When using the `SiadClient` the renter signatures were not being sent to the host causing the host to throw `invalid signature`. 

https://github.com/lukechampine/us/blob/36e1081712379a6af2b3f49ca4aadfb1b1786625/renter/renterutil/client.go#L162